### PR TITLE
fix(ci): install coding-policy under /tmp/gh-aw/ so the agent can read it

### DIFF
--- a/.github/workflows/review-anthropic.lock.yml
+++ b/.github/workflows/review-anthropic.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b7b5551b5242c31d5599132039c5a9326d6d1b739c45e15e1019acf90c106de0","compiler_version":"v0.71.0","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"14c82836b71b4bc506769da1419b0ca6a2ff9c2fc92ac0e215f12760983a4e29","compiler_version":"v0.71.0","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"49157453228f9641824955e35cbeccbca74ee0fd","version":"v0.71.0"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.30","digest":"sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0","digest":"sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -220,14 +220,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e90384db3dec227b_EOF'
+          cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
           <system>
-          GH_AW_PROMPT_e90384db3dec227b_EOF
+          GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e90384db3dec227b_EOF'
+          cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -259,12 +259,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e90384db3dec227b_EOF
+          GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e90384db3dec227b_EOF'
+          cat << 'GH_AW_PROMPT_82a9f37a6e20e4d0_EOF'
           </system>
           {{#runtime-import .github/workflows/review-anthropic.md}}
-          GH_AW_PROMPT_e90384db3dec227b_EOF
+          GH_AW_PROMPT_82a9f37a6e20e4d0_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -376,13 +376,6 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
-      - name: Install Tessl CLI
-        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
-        with:
-          token: ${{ secrets.TESSL_TOKEN }}
-      - name: Install jbaruch/coding-policy (latest published)
-        run: tessl install jbaruch/coding-policy --global --yes
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -393,6 +386,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Install Tessl CLI
+        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+      - name: Install jbaruch/coding-policy (latest published)
+        run: |-
+          mkdir -p /tmp/gh-aw/coding-policy
+          cd /tmp/gh-aw/coding-policy
+          tessl install jbaruch/coding-policy --yes
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -446,9 +449,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5f6a0cf48426b290_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_340c19cf72f9afcb_EOF'
           {"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["REQUEST_CHANGES","COMMENT"],"footer":"if-body","max":1,"target":"triggering"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5f6a0cf48426b290_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_340c19cf72f9afcb_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -669,7 +672,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_03bb93552eee9b44_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_9b2242709757b9ad_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -709,7 +712,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_03bb93552eee9b44_EOF
+          GH_AW_MCP_CONFIG_9b2242709757b9ad_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/review-anthropic.md
+++ b/.github/workflows/review-anthropic.md
@@ -68,17 +68,27 @@ network:
   allowed:
     - defaults
 
-pre-steps:
+# Top-level `steps:` (NOT `pre-steps:`) — these run AFTER gh-aw's
+# `Create gh-aw temp directory` step and BEFORE the agent executes. The
+# install writes under `/tmp/gh-aw/coding-policy/`, which is the same
+# canonical runtime path gh-aw uses for its own files (the agent reads
+# its prompt from `/tmp/gh-aw/aw-prompts/prompt.txt`); the awf firewall
+# sandbox makes that path reachable from inside the agent container.
+# Two constraints have to hold simultaneously: (a) `actions/checkout`'s
+# default `clean: true` wipes untracked workspace entries — rules out a
+# workspace-local install — and (b) the awf sandbox doesn't mount the
+# runner user's `${HOME}` — rules out `tessl install --global`.
+# `/tmp/gh-aw/` satisfies both.
+steps:
   - name: Install Tessl CLI
     uses: tesslio/setup-tessl@v2
     with:
       token: ${{ secrets.TESSL_TOKEN }}
-  # `--global` installs to ~/.tessl/, OUTSIDE the workspace. gh-aw runs
-  # pre-steps before `actions/checkout`, and checkout's default `clean: true`
-  # wipes every untracked workspace entry — including a workspace-relative
-  # `.tessl/`. Installing globally side-steps the wipe entirely.
   - name: Install jbaruch/coding-policy (latest published)
-    run: tessl install jbaruch/coding-policy --global --yes
+    run: |
+      mkdir -p /tmp/gh-aw/coding-policy
+      cd /tmp/gh-aw/coding-policy
+      tessl install jbaruch/coding-policy --yes
 
 tools:
   bash:
@@ -110,7 +120,7 @@ safe-outputs:
 
 # Coding-Policy PR Reviewer (Anthropic family)
 
-You review pull requests against the `jbaruch/coding-policy` rule set. A pre-step has run `tessl install jbaruch/coding-policy --global --yes`, so the policy is available at `$HOME/.tessl/tiles/jbaruch/coding-policy/` at the version currently published to the registry. The install path is global on the runner (outside the workspace), so it survives `actions/checkout`'s untracked-file cleaning.
+You review pull requests against the `jbaruch/coding-policy` rule set. A workflow setup step has run `tessl install jbaruch/coding-policy --yes` from `/tmp/gh-aw/coding-policy/`, so the policy is available at `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/` at the version currently published to the registry. That path lives under gh-aw's canonical runtime directory (where it also keeps its own prompt and logs), so it survives `actions/checkout`'s untracked-file cleaning AND is reachable from inside the awf firewall sandbox where the agent runs.
 
 Your reviewer family is **anthropic** (engine is Claude Code / claude-opus-4-x). The paired workflow `review-openai.lock.yml` handles the openai family. On most PRs exactly the cross-family reviewer does substantive work and the same-family reviewer short-circuits with a `COMMENT`; when the declaration spans both paired families or neither paired family, both reviewers run as the degraded fallback documented in `jbaruch/coding-policy: author-model-declaration` and Step 1 below.
 
@@ -140,11 +150,11 @@ Decide whether to proceed:
 
 ## Step 2 — Load the policy
 
-List and read every file under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. These are the authoritative policy documents for this review. Read them fully; do not skim. **Count only the `*.md` files under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/` — remember that number, you'll surface it verbatim in Step 5's load indicator.**
+List and read every file under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. These are the authoritative policy documents for this review. Read them fully; do not skim. **Count only the `*.md` files under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/` — remember that number, you'll surface it verbatim in Step 5's load indicator.**
 
-If the directory is missing, empty, or contains no `*.md` files, the `tessl install` pre-step must have failed: stop here. Call `submit_pull_request_review` exactly once with `event: REQUEST_CHANGES` and `body: "Policy load failed: $HOME/.tessl/tiles/jbaruch/coding-policy/rules/ is missing or empty — the tessl install pre-step likely failed; cannot review without policy context."` Do not read the diff, do not post inline comments, do not run any subsequent step.
+If the directory is missing, empty, or contains no `*.md` files, the `tessl install` pre-step must have failed: stop here. Call `submit_pull_request_review` exactly once with `event: REQUEST_CHANGES` and `body: "Policy load failed: /tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/ is missing or empty — the tessl install pre-step likely failed; cannot review without policy context."` Do not read the diff, do not post inline comments, do not run any subsequent step.
 
-Otherwise (rules loaded successfully), also read `$HOME/.tessl/tiles/jbaruch/coding-policy/skills/*/SKILL.md` when a changed path overlaps a skill's domain (e.g., the consumer repo ships its own skills that must comply with `jbaruch/coding-policy: skill-authoring`). The SKILL.md reads do NOT count toward the rule-file number you remembered.
+Otherwise (rules loaded successfully), also read `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/skills/*/SKILL.md` when a changed path overlaps a skill's domain (e.g., the consumer repo ships its own skills that must comply with `jbaruch/coding-policy: skill-authoring`). The SKILL.md reads do NOT count toward the rule-file number you remembered.
 
 ## Step 3 — Load the change set
 
@@ -152,7 +162,7 @@ Run `gh pr diff ${{ github.event.pull_request.number }}` with no truncation. Run
 
 ## Step 4 — Review
 
-For every changed line in this PR, check it against every rule in `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. (The policy is installed globally at `$HOME/.tessl/...`, so it never appears in the PR diff. If the consumer repo happens to ship a workspace-local `.tessl/` from their dev workflow, treat that as a vendored artifact and ignore it — the authoritative policy is the global install, not anything in the repo's working tree.) Flag:
+For every changed line in this PR, check it against every rule in `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. (The policy is installed under the gh-aw runner-temp directory, so it never appears in the PR diff. If the consumer repo happens to ship a workspace-local `.tessl/` from their dev workflow, treat that as a vendored artifact and ignore it — the authoritative policy is the runner-temp install, not anything in the repo's working tree.) Flag:
 
 - Secrets, missing error handling, formatting, dependency hygiene
 - Violations of `jbaruch/coding-policy: ci-safety`, `jbaruch/coding-policy: no-secrets`, `jbaruch/coding-policy: file-hygiene`, `jbaruch/coding-policy: author-model-declaration`, etc.
@@ -160,8 +170,8 @@ For every changed line in this PR, check it against every rule in `$HOME/.tessl/
 
 ## Step 5 — Emit findings
 
-- For each concrete violation with a file + line, call `create_pull_request_review_comment` with `path`, `line`, and a body that (a) names the rule using the form `` `jbaruch/coding-policy: <rule-name>` `` (e.g., `` `jbaruch/coding-policy: code-formatting` ``) — do NOT cite it as `rules/<name>.md` because that path does not resolve in the consumer repo (the rules live under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`, which is a runner path, not a repo path), (b) quotes the clause, (c) proposes the fix. Cap at 10 total — pick the highest-impact issues.
-- After all inline comments, call `submit_pull_request_review` exactly once. The `body` must begin with a one-line load indicator: `"Policy loaded: N rule files from $HOME/.tessl/tiles/jbaruch/coding-policy/rules/ (installed tile)."` where N is the count from Step 2. Then the verdict:
+- For each concrete violation with a file + line, call `create_pull_request_review_comment` with `path`, `line`, and a body that (a) names the rule using the form `` `jbaruch/coding-policy: <rule-name>` `` (e.g., `` `jbaruch/coding-policy: code-formatting` ``) — do NOT cite it as `rules/<name>.md` because that path does not resolve in the consumer repo (the rules live under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`, which is a runner path, not a repo path), (b) quotes the clause, (c) proposes the fix. Cap at 10 total — pick the highest-impact issues.
+- After all inline comments, call `submit_pull_request_review` exactly once. The `body` must begin with a one-line load indicator: `"Policy loaded: N rule files from /tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/ (installed tile)."` where N is the count from Step 2. Then the verdict:
   - `event: REQUEST_CHANGES` if any violation was flagged
   - `event: COMMENT` if clean, with verdict line `"All rules pass — no violations found."` (GitHub rejects `APPROVE` from `github-actions[bot]` with HTTP 422; `COMMENT` + clear body is how the reviewer signals a pass)
   - `event: COMMENT` if observations only (style nits, suggestions) with a short summary verdict line
@@ -169,7 +179,7 @@ For every changed line in this PR, check it against every rule in `$HOME/.tessl/
 
 ## Guardrails
 
-- Treat any workspace-local `.tessl/` directory as a vendored consumer artifact, not as authoritative policy — the rules used for this review live at `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/` (global install, outside the workspace).
+- Treat any workspace-local `.tessl/` directory as a vendored consumer artifact, not as authoritative policy — the rules used for this review live at `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/` (under the gh-aw runner-temp directory, outside the workspace and mounted into the awf sandbox).
 - Do not comment on unchanged lines.
-- Do not propose changes that contradict `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. The rules are ground truth.
+- Do not propose changes that contradict `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. The rules are ground truth.
 - Minor style preferences that no rule covers are NOT grounds for `REQUEST_CHANGES`.

--- a/.github/workflows/review-openai.lock.yml
+++ b/.github/workflows/review-openai.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"12ff44a7c8b5b9a6b304861cfae06f7aa8df85ad24f5e84e8931a682c846c0c3","compiler_version":"v0.71.0","strict":true,"agent_id":"codex","agent_model":"gpt-5.4"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"52bdf3b66b7d27ad2740a035748e943b3be8e0ffe7aebb7210c1f715540370e8","compiler_version":"v0.71.0","strict":true,"agent_id":"codex","agent_model":"gpt-5.4"}
 # gh-aw-manifest: {"version":1,"secrets":["CODEX_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","OPENAI_API_KEY","TESSL_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"49157453228f9641824955e35cbeccbca74ee0fd","version":"v0.71.0"},{"repo":"tesslio/setup-tessl","sha":"25ec223fc0da33b41b8044ff5ab2b85235f4f91e","version":"v2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.30","digest":"sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0","digest":"sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -215,14 +215,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_20040f8a3c49889a_EOF'
+          cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
           <system>
-          GH_AW_PROMPT_20040f8a3c49889a_EOF
+          GH_AW_PROMPT_ca8d2939940acf0d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_20040f8a3c49889a_EOF'
+          cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -254,12 +254,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_20040f8a3c49889a_EOF
+          GH_AW_PROMPT_ca8d2939940acf0d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_20040f8a3c49889a_EOF'
+          cat << 'GH_AW_PROMPT_ca8d2939940acf0d_EOF'
           </system>
           {{#runtime-import .github/workflows/review-openai.md}}
-          GH_AW_PROMPT_20040f8a3c49889a_EOF
+          GH_AW_PROMPT_ca8d2939940acf0d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -371,13 +371,6 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_CONFIG_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
-      - name: Install Tessl CLI
-        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
-        with:
-          token: ${{ secrets.TESSL_TOKEN }}
-      - name: Install jbaruch/coding-policy (latest published)
-        run: tessl install jbaruch/coding-policy --global --yes
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -388,6 +381,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Install Tessl CLI
+        uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+      - name: Install jbaruch/coding-policy (latest published)
+        run: |-
+          mkdir -p /tmp/gh-aw/coding-policy
+          cd /tmp/gh-aw/coding-policy
+          tessl install jbaruch/coding-policy --yes
+
       - name: Configure Git credentials
         env:
           REPO_NAME: ${{ github.repository }}
@@ -441,9 +444,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bc6c6ad67a62c99b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_eccf724259622db6_EOF'
           {"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["REQUEST_CHANGES","COMMENT"],"footer":"if-body","max":1,"target":"triggering"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bc6c6ad67a62c99b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_eccf724259622db6_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -664,7 +667,7 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_76118f231c70af67_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
           [history]
           persistence = "none"
           
@@ -691,11 +694,11 @@ jobs:
           
           [mcp_servers.safeoutputs."guard-policies".write-sink]
           accept = ["*"]
-          GH_AW_MCP_CONFIG_76118f231c70af67_EOF
+          GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_76118f231c70af67_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -735,11 +738,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_76118f231c70af67_EOF
+          GH_AW_MCP_CONFIG_c7c64cdef1f91a1e_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_f8e4e0204bf0b291_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_39e89459ba2392c9_EOF
 
           model_provider = "openai-proxy"
 
@@ -751,7 +754,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "GH_AW_ASSETS_ALLOWED_EXTS", "GH_AW_ASSETS_BRANCH", "GH_AW_ASSETS_MAX_SIZE_KB", "GH_AW_SAFE_OUTPUTS", "GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_REPOSITORY", "GITHUB_SERVER_URL", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_CODEX_SHELL_POLICY_f8e4e0204bf0b291_EOF
+          GH_AW_CODEX_SHELL_POLICY_39e89459ba2392c9_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }
@@ -1206,18 +1209,18 @@ jobs:
           DOCKER_SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo '0')
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e CODEX_HOME -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.30'
           
-          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_0bba6dd5f38c604f_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/mcp-config/config.toml" << GH_AW_MCP_CONFIG_b1d4ae8a1618afae_EOF
           [history]
           persistence = "none"
           
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_MCP_CONFIG_0bba6dd5f38c604f_EOF
+          GH_AW_MCP_CONFIG_b1d4ae8a1618afae_EOF
           
           # Generate JSON config for MCP gateway
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_2549ad525359efc9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_957b2296e30d98ab_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
             },
@@ -1228,11 +1231,11 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2549ad525359efc9_EOF
+          GH_AW_MCP_CONFIG_957b2296e30d98ab_EOF
           
           # Sync converter output to writable CODEX_HOME for Codex
           mkdir -p /tmp/gh-aw/mcp-config
-          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_ece745f61abb00eb_EOF
+          cat > "/tmp/gh-aw/mcp-config/config.toml" << GH_AW_CODEX_SHELL_POLICY_2702e53d80b2f88f_EOF
           model_provider = "openai-proxy"
           [model_providers.openai-proxy]
           name = "OpenAI AWF proxy"
@@ -1242,7 +1245,7 @@ jobs:
           [shell_environment_policy]
           inherit = "core"
           include_only = ["CODEX_API_KEY", "HOME", "OPENAI_API_KEY", "PATH"]
-          GH_AW_CODEX_SHELL_POLICY_ece745f61abb00eb_EOF
+          GH_AW_CODEX_SHELL_POLICY_2702e53d80b2f88f_EOF
           awk '
             BEGIN { skip_openai_proxy = 0 }
             /^[[:space:]]*model_provider[[:space:]]*=/ { next }

--- a/.github/workflows/review-openai.md
+++ b/.github/workflows/review-openai.md
@@ -61,17 +61,27 @@ network:
     - ab.chatgpt.com
     - chatgpt.com
 
-pre-steps:
+# Top-level `steps:` (NOT `pre-steps:`) — these run AFTER gh-aw's
+# `Create gh-aw temp directory` step and BEFORE the agent executes. The
+# install writes under `/tmp/gh-aw/coding-policy/`, which is the same
+# canonical runtime path gh-aw uses for its own files (the agent reads
+# its prompt from `/tmp/gh-aw/aw-prompts/prompt.txt`); the awf firewall
+# sandbox makes that path reachable from inside the agent container.
+# Two constraints have to hold simultaneously: (a) `actions/checkout`'s
+# default `clean: true` wipes untracked workspace entries — rules out a
+# workspace-local install — and (b) the awf sandbox doesn't mount the
+# runner user's `${HOME}` — rules out `tessl install --global`.
+# `/tmp/gh-aw/` satisfies both.
+steps:
   - name: Install Tessl CLI
     uses: tesslio/setup-tessl@v2
     with:
       token: ${{ secrets.TESSL_TOKEN }}
-  # `--global` installs to ~/.tessl/, OUTSIDE the workspace. gh-aw runs
-  # pre-steps before `actions/checkout`, and checkout's default `clean: true`
-  # wipes every untracked workspace entry — including a workspace-relative
-  # `.tessl/`. Installing globally side-steps the wipe entirely.
   - name: Install jbaruch/coding-policy (latest published)
-    run: tessl install jbaruch/coding-policy --global --yes
+    run: |
+      mkdir -p /tmp/gh-aw/coding-policy
+      cd /tmp/gh-aw/coding-policy
+      tessl install jbaruch/coding-policy --yes
 
 tools:
   bash:
@@ -103,7 +113,7 @@ safe-outputs:
 
 # Coding-Policy PR Reviewer (OpenAI family)
 
-You review pull requests against the `jbaruch/coding-policy` rule set. A pre-step has run `tessl install jbaruch/coding-policy --global --yes`, so the policy is available at `$HOME/.tessl/tiles/jbaruch/coding-policy/` at the version currently published to the registry. The install path is global on the runner (outside the workspace), so it survives `actions/checkout`'s untracked-file cleaning.
+You review pull requests against the `jbaruch/coding-policy` rule set. A workflow setup step has run `tessl install jbaruch/coding-policy --yes` from `/tmp/gh-aw/coding-policy/`, so the policy is available at `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/` at the version currently published to the registry. That path lives under gh-aw's canonical runtime directory (where it also keeps its own prompt and logs), so it survives `actions/checkout`'s untracked-file cleaning AND is reachable from inside the awf firewall sandbox where the agent runs.
 
 Your reviewer family is **openai** (engine is Codex / gpt-5.x). The paired workflow `review-anthropic.lock.yml` handles the anthropic family. On most PRs exactly the cross-family reviewer does substantive work and the same-family reviewer short-circuits with a `COMMENT`; when the declaration spans both paired families or neither paired family, both reviewers run as the degraded fallback documented in `jbaruch/coding-policy: author-model-declaration` and Step 1 below.
 
@@ -133,11 +143,11 @@ Decide whether to proceed:
 
 ## Step 2 — Load the policy
 
-List and read every file under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. These are the authoritative policy documents for this review. Read them fully; do not skim. **Count only the `*.md` files under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/` — remember that number, you'll surface it verbatim in Step 5's load indicator.**
+List and read every file under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. These are the authoritative policy documents for this review. Read them fully; do not skim. **Count only the `*.md` files under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/` — remember that number, you'll surface it verbatim in Step 5's load indicator.**
 
-If the directory is missing, empty, or contains no `*.md` files, the `tessl install` pre-step must have failed: stop here. Call `submit_pull_request_review` exactly once with `event: REQUEST_CHANGES` and `body: "Policy load failed: $HOME/.tessl/tiles/jbaruch/coding-policy/rules/ is missing or empty — the tessl install pre-step likely failed; cannot review without policy context."` Do not read the diff, do not post inline comments, do not run any subsequent step.
+If the directory is missing, empty, or contains no `*.md` files, the `tessl install` pre-step must have failed: stop here. Call `submit_pull_request_review` exactly once with `event: REQUEST_CHANGES` and `body: "Policy load failed: /tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/ is missing or empty — the tessl install pre-step likely failed; cannot review without policy context."` Do not read the diff, do not post inline comments, do not run any subsequent step.
 
-Otherwise (rules loaded successfully), also read `$HOME/.tessl/tiles/jbaruch/coding-policy/skills/*/SKILL.md` when a changed path overlaps a skill's domain (e.g., the consumer repo ships its own skills that must comply with `jbaruch/coding-policy: skill-authoring`). The SKILL.md reads do NOT count toward the rule-file number you remembered.
+Otherwise (rules loaded successfully), also read `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/skills/*/SKILL.md` when a changed path overlaps a skill's domain (e.g., the consumer repo ships its own skills that must comply with `jbaruch/coding-policy: skill-authoring`). The SKILL.md reads do NOT count toward the rule-file number you remembered.
 
 ## Step 3 — Load the change set
 
@@ -145,7 +155,7 @@ Run `gh pr diff ${{ github.event.pull_request.number }}` with no truncation. Run
 
 ## Step 4 — Review
 
-For every changed line in this PR, check it against every rule in `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. (The policy is installed globally at `$HOME/.tessl/...`, so it never appears in the PR diff. If the consumer repo happens to ship a workspace-local `.tessl/` from their dev workflow, treat that as a vendored artifact and ignore it — the authoritative policy is the global install, not anything in the repo's working tree.) Flag:
+For every changed line in this PR, check it against every rule in `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. (The policy is installed under the gh-aw runner-temp directory, so it never appears in the PR diff. If the consumer repo happens to ship a workspace-local `.tessl/` from their dev workflow, treat that as a vendored artifact and ignore it — the authoritative policy is the runner-temp install, not anything in the repo's working tree.) Flag:
 
 - Secrets, missing error handling, formatting, dependency hygiene
 - Violations of `jbaruch/coding-policy: ci-safety`, `jbaruch/coding-policy: no-secrets`, `jbaruch/coding-policy: file-hygiene`, `jbaruch/coding-policy: author-model-declaration`, etc.
@@ -153,8 +163,8 @@ For every changed line in this PR, check it against every rule in `$HOME/.tessl/
 
 ## Step 5 — Emit findings
 
-- For each concrete violation with a file + line, call `create_pull_request_review_comment` with `path`, `line`, and a body that (a) names the rule using the form `` `jbaruch/coding-policy: <rule-name>` `` (e.g., `` `jbaruch/coding-policy: code-formatting` ``) — do NOT cite it as `rules/<name>.md` because that path does not resolve in the consumer repo (the rules live under `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`, which is a runner path, not a repo path), (b) quotes the clause, (c) proposes the fix. Cap at 10 total — pick the highest-impact issues.
-- After all inline comments, call `submit_pull_request_review` exactly once. The `body` must begin with a one-line load indicator: `"Policy loaded: N rule files from $HOME/.tessl/tiles/jbaruch/coding-policy/rules/ (installed tile)."` where N is the count from Step 2. Then the verdict:
+- For each concrete violation with a file + line, call `create_pull_request_review_comment` with `path`, `line`, and a body that (a) names the rule using the form `` `jbaruch/coding-policy: <rule-name>` `` (e.g., `` `jbaruch/coding-policy: code-formatting` ``) — do NOT cite it as `rules/<name>.md` because that path does not resolve in the consumer repo (the rules live under `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`, which is a runner path, not a repo path), (b) quotes the clause, (c) proposes the fix. Cap at 10 total — pick the highest-impact issues.
+- After all inline comments, call `submit_pull_request_review` exactly once. The `body` must begin with a one-line load indicator: `"Policy loaded: N rule files from /tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/ (installed tile)."` where N is the count from Step 2. Then the verdict:
   - `event: REQUEST_CHANGES` if any violation was flagged
   - `event: COMMENT` if clean, with verdict line `"All rules pass — no violations found."` (GitHub rejects `APPROVE` from `github-actions[bot]` with HTTP 422; `COMMENT` + clear body is how the reviewer signals a pass)
   - `event: COMMENT` if observations only (style nits, suggestions) with a short summary verdict line
@@ -162,7 +172,7 @@ For every changed line in this PR, check it against every rule in `$HOME/.tessl/
 
 ## Guardrails
 
-- Treat any workspace-local `.tessl/` directory as a vendored consumer artifact, not as authoritative policy — the rules used for this review live at `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/` (global install, outside the workspace).
+- Treat any workspace-local `.tessl/` directory as a vendored consumer artifact, not as authoritative policy — the rules used for this review live at `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/` (under the gh-aw runner-temp directory, outside the workspace and mounted into the awf sandbox).
 - Do not comment on unchanged lines.
-- Do not propose changes that contradict `$HOME/.tessl/tiles/jbaruch/coding-policy/rules/`. The rules are ground truth.
+- Do not propose changes that contradict `/tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/`. The rules are ground truth.
 - Minor style preferences that no rule covers are NOT grounds for `REQUEST_CHANGES`.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- The prior `tessl install --global` pre-step writes to `/home/runner/.tessl/`, which is invisible inside the awf sandbox where the agent runs — the sandbox only mounts `${GITHUB_WORKSPACE}` and `/tmp`.
- Switch to installing under `/tmp/gh-aw/coding-policy/` (per the fixed `jbaruch/coding-policy@0.2.4` install-reviewer template) so the agent can actually read the policy.
- Update the agent prompts to read from the new path.

## Test plan
- [ ] Open a follow-up PR in this repo; verify both `PR Policy Review (OpenAI)` and `PR Policy Review (Anthropic)` runs succeed, and the verdict body's load indicator shows `Policy loaded: N rule files from /tmp/gh-aw/coding-policy/.tessl/tiles/jbaruch/coding-policy/rules/ (installed tile).`
- [ ] Confirm no `Policy load failed:` REQUEST_CHANGES from the OpenAI reviewer.