### PR TITLE
docs(surface-sync): add README + CHANGELOG, declare entrypoint in tile.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+### Surface sync
+
+- `tile.json` adds `entrypoint: README.md` per `jbaruch/coding-policy: context-artifacts`.
+- `README.md` and `CHANGELOG.md` introduced (none existed previously). Both will be maintained going forward as required by the policy.
+
+The README's rules-table summaries are auto-extracted first-paragraph excerpts from each rule file. Refine them per rule when the wording is misleading; this commit is a structural bootstrap, not authored prose.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ tessl install jbaruch/nanoclaw-trusted
 | [daily-discoveries-rule](rules/daily-discoveries-rule.md) | When you learn something new and operationally important — a workflow, where something lives, how something works, a tool to use for a specific task — immediately write it to… |
 | [ground-truth-trusted](rules/ground-truth-trusted.md) | Extends the core ground-truth rule with verification methods and computation available to trusted containers via Composio. |
 | [memory-file-locations](rules/memory-file-locations.md) | 1. **All typed memory files go in `/workspace/trusted/` root** — never in `/workspace/trusted/memory/`. The `memory/` subdirectory is ONLY for daily logs and daily_discoveries. |
-| [no-orphan-tasks](rules/no-orphan-tasks.md) | **Never create a standalone scheduled task for something that can go into an existing scheduled workflow.** |
+| [no-orphan-tasks](rules/no-orphan-tasks.md) | Before scheduling any new recurring task, check: |
 | [proactive-fact-saving](rules/proactive-fact-saving.md) | Personal facts mentioned in conversation must be saved to trusted memory IMMEDIATELY — not at end of session, not during archival, not "when non-trivial." At first mention. |
-| [session-bootstrap](rules/session-bootstrap.md) | **YOUR VERY FIRST ACTION in every new session — before responding to ANY message — is to run this Bash command:** |
+| [session-bootstrap](rules/session-bootstrap.md) | Then write the sentinel: `echo "done" > /tmp/session_bootstrapped` |
 | [skill-dependencies](rules/skill-dependencies.md) | Skills that invoke or depend on other skills. Read this to understand execution order and shared state. |
 | [trusted-behavior](rules/trusted-behavior.md) | Extends core-behavior with additional rules for trusted and main containers. Everything in core still applies — this adds to it. |
 | [verification-protocol](rules/verification-protocol.md) | After these actions, verify independently before confirming to the user: |
@@ -30,7 +30,7 @@ tessl install jbaruch/nanoclaw-trusted
 
 | Skill | Description |
 |-------|-------------|
-| [check-system-health](skills/check-system-health/SKILL.md) | name: check-system-health |
-| [trusted-memory](skills/trusted-memory/SKILL.md) | name: trusted-memory |
+| [check-system-health](skills/check-system-health/SKILL.md) | Check NanoClaw system health — stuck tasks, DB size, task run failures. Uses /workspace/store/messages.db directly. Use as part of heartbeat or standalone. Triggers on "system health", "check tasks",… |
+| [trusted-memory](skills/trusted-memory/SKILL.md) | Session bootstrap and rolling memory updates for trusted containers. On session start, reads MEMORY.md (permanent facts), RUNBOOK.md (operational workflows), recent daily and weekly logs, and… |
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# jbaruch/nanoclaw-trusted
+
+[![tessl](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.tessl.io%2Fv1%2Fbadges%2Fjbaruch%2Fnanoclaw-trusted)](https://tessl.io/registry/jbaruch/nanoclaw-trusted)
+
+Rules for trusted NanoClaw groups. Shared memory, session bootstrap, cross-group memory updates. Loaded for trusted and admin scope.
+
+## Installation
+
+```
+tessl install jbaruch/nanoclaw-trusted
+```
+
+## Rules
+
+| Rule | Summary |
+|------|---------|
+| [compaction-aware-summaries](rules/compaction-aware-summaries.md) | When Claude Code compacts context, the summary must preserve information that cannot be recovered from files alone. |
+| [daily-discoveries-rule](rules/daily-discoveries-rule.md) | When you learn something new and operationally important — a workflow, where something lives, how something works, a tool to use for a specific task — immediately write it to… |
+| [ground-truth-trusted](rules/ground-truth-trusted.md) | Extends the core ground-truth rule with verification methods and computation available to trusted containers via Composio. |
+| [memory-file-locations](rules/memory-file-locations.md) | 1. **All typed memory files go in `/workspace/trusted/` root** — never in `/workspace/trusted/memory/`. The `memory/` subdirectory is ONLY for daily logs and daily_discoveries. |
+| [no-orphan-tasks](rules/no-orphan-tasks.md) | **Never create a standalone scheduled task for something that can go into an existing scheduled workflow.** |
+| [proactive-fact-saving](rules/proactive-fact-saving.md) | Personal facts mentioned in conversation must be saved to trusted memory IMMEDIATELY — not at end of session, not during archival, not "when non-trivial." At first mention. |
+| [session-bootstrap](rules/session-bootstrap.md) | **YOUR VERY FIRST ACTION in every new session — before responding to ANY message — is to run this Bash command:** |
+| [skill-dependencies](rules/skill-dependencies.md) | Skills that invoke or depend on other skills. Read this to understand execution order and shared state. |
+| [trusted-behavior](rules/trusted-behavior.md) | Extends core-behavior with additional rules for trusted and main containers. Everything in core still applies — this adds to it. |
+| [verification-protocol](rules/verification-protocol.md) | After these actions, verify independently before confirming to the user: |
+| [wiki-awareness](rules/wiki-awareness.md) | A persistent personal wiki lives at `/workspace/trusted/wiki/` with raw sources at `/workspace/trusted/sources/`. |
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| [check-system-health](skills/check-system-health/SKILL.md) | name: check-system-health |
+| [trusted-memory](skills/trusted-memory/SKILL.md) | name: trusted-memory |
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.

--- a/tile.json
+++ b/tile.json
@@ -2,6 +2,7 @@
   "name": "jbaruch/nanoclaw-trusted",
   "version": "0.1.41",
   "summary": "Rules for trusted NanoClaw groups. Shared memory, session bootstrap, cross-group memory updates. Loaded for trusted and main containers only.",
+  "entrypoint": "README.md",
   "private": false,
   "rules": {
     "daily-discoveries-rule": {


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- Pre-existing fleet-wide gap: `tile.json` lacked `entrypoint`, and `README.md` / `CHANGELOG.md` didn't exist. `jbaruch/coding-policy: context-artifacts` requires all three.
- Bootstrap minimal versions: tessl-badge README with auto-summary rules + skills tables, Unreleased CHANGELOG entry, `entrypoint: README.md` in tile.json.

## Test plan

- [ ] Re-review with the gh-aw OpenAI policy reviewer — the surface-sync clause should pass on this PR.
- [ ] Read through the rules-table summaries; any misleading auto-extracted line gets a one-row refinement (separate commit).