### PR TITLE
fix(rules): add missing alwaysApply: true frontmatter to all rule files

### DIFF
--- a/rules/compaction-aware-summaries.md
+++ b/rules/compaction-aware-summaries.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Compaction-Aware Summaries
 
 When Claude Code compacts context, the summary must preserve information that cannot be recovered from files alone.

--- a/rules/daily-discoveries-rule.md
+++ b/rules/daily-discoveries-rule.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Daily Discoveries Rule
 
 When you learn something new and operationally important — a workflow, where something lives, how something works, a tool to use for a specific task — immediately write it to `/workspace/trusted/memory/daily_discoveries.md`:

--- a/rules/ground-truth-trusted.md
+++ b/rules/ground-truth-trusted.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Ground Truth — Trusted Extensions
 
 Extends the core ground-truth rule with verification methods and computation available to trusted containers via Composio.

--- a/rules/memory-file-locations.md
+++ b/rules/memory-file-locations.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Memory File Locations
 
 ## Directory structure

--- a/rules/no-orphan-tasks.md
+++ b/rules/no-orphan-tasks.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # No Orphan Scheduled Tasks
 
 ## The Rule

--- a/rules/proactive-fact-saving.md
+++ b/rules/proactive-fact-saving.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Proactive Fact Saving
 
 Personal facts mentioned in conversation must be saved to trusted memory IMMEDIATELY — not at end of session, not during archival, not "when non-trivial." At first mention.

--- a/rules/session-bootstrap.md
+++ b/rules/session-bootstrap.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Session Bootstrap — MANDATORY First Action
 
 **YOUR VERY FIRST ACTION in every new session — before responding to ANY message — is to run this Bash command:**

--- a/rules/skill-dependencies.md
+++ b/rules/skill-dependencies.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Skill Dependencies
 
 Skills that invoke or depend on other skills. Read this to understand execution order and shared state.

--- a/rules/trusted-behavior.md
+++ b/rules/trusted-behavior.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Trusted Behavior
 
 Extends core-behavior with additional rules for trusted and main containers. Everything in core still applies — this adds to it.

--- a/rules/verification-protocol.md
+++ b/rules/verification-protocol.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 ## Verification Protocol
 
 After these actions, verify independently before confirming to the user:

--- a/rules/wiki-awareness.md
+++ b/rules/wiki-awareness.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Wiki Awareness
 
 A persistent personal wiki lives at `/workspace/trusted/wiki/` with raw sources at `/workspace/trusted/sources/`.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- `jbaruch/coding-policy: context-artifacts` requires every rule file to declare `alwaysApply: true` in its frontmatter.
- Every rule in this tile predates the policy and shipped without that frontmatter. Add it across the board.
- Files that already had a `---` frontmatter block get the key inserted inside; files with no frontmatter at all get a full 3-line prepend.

## Test plan

- [ ] Re-review with the gh-aw OpenAI policy reviewer; the `context-artifacts` rule-format clause should pass on every changed file.
- [ ] Spot-check that the rule body content is unchanged byte-for-byte after the frontmatter — only the frontmatter delta should appear in the diff.