### PR TITLE
audit: §10 mechanical hygiene — sqlite3.connect timeout in inline blocks

### DIFF
--- a/skills/check-system-health/SKILL.md
+++ b/skills/check-system-health/SKILL.md
@@ -14,7 +14,7 @@ DB is at `/workspace/store/messages.db`. Run each check below.
 ```bash
 python3 -c "
 import sqlite3
-conn = sqlite3.connect('/workspace/store/messages.db')
+conn = sqlite3.connect('/workspace/store/messages.db', timeout=5)
 rows = conn.execute(\"SELECT id, substr(prompt, 1, 50), next_run FROM scheduled_tasks WHERE status='active' AND next_run <= datetime('now', '-5 minutes')\").fetchall()
 for r in rows: print(r)
 print(f'stuck={len(rows)}')
@@ -29,7 +29,7 @@ conn.close()
 ```bash
 python3 -c "
 import sqlite3, os
-conn = sqlite3.connect('/workspace/store/messages.db')
+conn = sqlite3.connect('/workspace/store/messages.db', timeout=5)
 msg_count = conn.execute('SELECT COUNT(*) FROM messages').fetchone()[0]
 log_count = conn.execute('SELECT COUNT(*) FROM task_run_logs').fetchone()[0]
 conn.close()

--- a/skills/trusted-memory/SKILL.md
+++ b/skills/trusted-memory/SKILL.md
@@ -114,7 +114,7 @@ If `needs_bootstrap` is **True** → run all steps below in order:
 
 ```python
 import sqlite3, json
-conn = sqlite3.connect('/workspace/store/messages.db')
+conn = sqlite3.connect('/workspace/store/messages.db', timeout=5)
 row = conn.execute('SELECT session_id FROM sessions LIMIT 1').fetchone()
 current_session_id = row[0] if row else None
 conn.close()


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

`docs/tile-plugin-audit.md` §10 hygiene item: *"sqlite3.connect without timeout."* Three inline `sqlite3.connect('/workspace/store/messages.db')` calls in SKILL.md prose blocks the agent reproduces verbatim. Without an explicit timeout, a busy DB blocks indefinitely on the default infinite wait — exactly the bug §10 calls out.

Switched all three to `timeout=5` (the convention from §5 "Subprocess paths"):

- `skills/check-system-health/SKILL.md` — Step 1 (stuck-task scan) and Step 2 (DB size).
- `skills/trusted-memory/SKILL.md` — Step 7 session_id read.

Closes part of #1.

## Test plan

- [ ] OpenAI policy reviewer passes.
- [ ] Inline blocks remain syntactically valid Python (visual check); no runtime behavior change beyond the timeout itself.