### PR TITLE
chore: replace Baruch in rule text with role-generic "the owner"

### DIFF
--- a/rules/no-orphan-tasks.md
+++ b/rules/no-orphan-tasks.md
@@ -18,7 +18,7 @@ Before scheduling any new recurring task, check:
 
 Any daily recurring check that:
 - Doesn't need to run more than once a day
-- Produces results Baruch can see in the morning
+- Produces results the owner can see in the morning
 - Involves fetching data, checking state, or generating a report
 
 Examples: YouTube comment checks, GitHub activity summaries, CFP state refresh, email triage.

--- a/rules/trusted-behavior.md
+++ b/rules/trusted-behavior.md
@@ -47,7 +47,7 @@ In trusted groups, you're not a guest — you're a participant. The default-sile
 - Offer help when you spot a problem you can solve
 - React to things you find interesting or relevant — **a reaction alone is complete participation**. No text needed to complete it.
 
-The test: "Would Baruch want to hear this?" If yes, say it. If you're padding silence — don't.
+The test: "Would the owner want to hear this?" If yes, say it. If you're padding silence — don't.
 
 Reacting to a message = normal, appropriate group participation.
 Responding with text = only when you have something genuinely worth saying.


### PR DESCRIPTION
**Author-Model:** human

## Summary

Two rule lines anchored owner identity to "Baruch" in ways that biased consuming bots:

- `rules/trusted-behavior.md` — proactive-participation test "Would Baruch want to hear this?" → "Would the owner want to hear this?"
- `rules/no-orphan-tasks.md` — nightly-housekeeping rationale "results Baruch can see in the morning" → "results the owner can see in the morning"

Without this, models reading the tile corpus in someone else's deployment can pick up "owner = Baruch" and refuse legitimate requests from the actual owner with "I only have access to Baruch's data, not yours."

Behavioral test is the same; the placeholder used to teach it is now role-generic.

## Test plan

- [ ] No `Baruch`/`baruch` strings remain in `rules/` or `skills/`
- [ ] Bots in non-Baruch deployments stop misidentifying ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)