### PR TITLE
feat: promote 1 item(s) from Agent staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Skills
 
+- **trusted-memory: hook-aware bootstrap note** — Restores the 2-line clarification that the agent-runner's `session-start-auto-context` hook (qwibitai/nanoclaw#141) auto-injects MEMORY.md, RUNBOOK.md, and the most-recent daily log before this skill runs, so the bootstrap's value is the **broader** set the hook does NOT cover (group-shared `trusted/` memory, weekly logs, `highlights.md`) plus the per-session sentinel + state-stamping. The note originated in admin's deleted copy (`nanoclaw-admin@13de2a98`) and was lost when admin's `trusted-memory` was deleted in `nanoclaw-admin#60` (rebase resolved the modify/delete conflict by keeping the deletion). Trusted's canonical copy didn't carry it forward; this restores the context.
+
 - **trusted-memory absorbs admin's improvements** — The admin tile carried a parallel `trusted-memory` copy that diverged after `nanoclaw-admin#31` extracted inline Python into helper scripts. Per audit decision (closes `nanoclaw-admin#52`), trusted is the canonical home for this skill. This change pulls admin's structural improvements into trusted's copy:
   - `scripts/needs-bootstrap.py` (new) — sentinel-vs-`$CLAUDE_SESSION_ID` check, replacing the inline 8-line block; exit 0 = bootstrap needed, exit 1 = skip.
   - `scripts/register-session.py` (new) — atomic `session-state.json` + `/tmp/session_bootstrapped` write under `fcntl.LOCK_EX`. Reads session_id from `/workspace/store/messages.db` with a 10s timeout; tolerates `sqlite3.Error` as `session_id=None` rather than crashing the whole bootstrap; refuses to write an empty sentinel (would silently disable bootstrap forever).

--- a/skills/trusted-memory/SKILL.md
+++ b/skills/trusted-memory/SKILL.md
@@ -88,6 +88,8 @@ Max 200 lines. When approaching the limit, consolidate or remove stale entries.
 
 ## Session Bootstrap
 
+> The agent-runner now auto-injects MEMORY.md, RUNBOOK.md, and the most-recent daily log via the `session-start-auto-context` hook (qwibitai/nanoclaw#141), so those three files are already in context when this skill runs. This skill's bootstrap still adds value because it reads the **broader** set the hook does NOT cover — group-shared `trusted/` memory, weekly logs, and `highlights.md` — plus does the per-session sentinel + state-stamping.
+
 First, check if bootstrap is needed. The sentinel is keyed to the current session ID so a new session within the same container still triggers bootstrap:
 
 ```


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Restores a 2-line clarification at the top of `## Session Bootstrap` in `skills/trusted-memory/SKILL.md` that the agent-runner's `session-start-auto-context` hook (qwibitai/nanoclaw#141) auto-injects MEMORY.md, RUNBOOK.md, and the most-recent daily log before the skill runs — so the bootstrap's value is the **broader** set the hook does not cover (group-shared `trusted/` memory, weekly logs, `highlights.md`) plus the per-session sentinel + state-stamping.

## Why

The note originated in admin's deleted copy (`nanoclaw-admin@13de2a98`) and was lost when admin's `trusted-memory` was deleted in [admin#60](https://github.com/jbaruch/nanoclaw-admin/pull/60) — the rebase resolved the modify/delete conflict by keeping the deletion. Trusted's canonical copy never carried it forward, and re-reading the skill without that context makes the bootstrap look redundant with the hook.

## What changed

- `skills/trusted-memory/SKILL.md` — 2 inserted lines above the first paragraph of `## Session Bootstrap`.
- `CHANGELOG.md` — `### Skills` entry under Unreleased noting the restoration (surface-sync per `coding-policy: context-artifacts`).

No script changes; existing `needs-bootstrap.py` and `register-session.py` are still authoritative for the sentinel + state-stamping that the note describes.

## Test plan

- [x] Local skill review score: 90% (≥85 threshold).
- [ ] Copilot review clean.
- [ ] CI green (publish-tile + test workflow on the merged tile).

## Pipeline

Promoted via `scripts/promote-from-host.sh` (host-side staging → tile repo PR per `nanoclaw-host: host-conventions`). Iteration via fixups on this branch — second commit (`3dce933`) is the CHANGELOG sync.