### PR TITLE
feat(state): #298 session-state tile-side rewrite (trusted half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Skills — `session-state.json` SQLite migration (tile-side, `jbaruch/nanoclaw#298`)
+
+- **`trusted-memory/scripts/register-session.py` — rewrite to UPSERT `trusted_sessions` + `trusted_session_singleton` rows in SQLite.** The two new tables landed in the orchestrator's state-006 migration. Per-session UPSERT keyed on `session_name` (PK) + per-id UPSERT keyed on `id=1` (singleton CHECK) make sibling-row clobber impossible by construction. The JSON-era `fcntl.LOCK_EX` + tempfile + fsync + chmod-preserve + `os.replace` ceremony retires for both writes; only the `/tmp/session_bootstrapped` sentinel remains file-based (it's a per-container, non-shared bootstrap marker — SQLite isn't the right tool). The singleton UPSERT deliberately omits `pending_response` and `muted_threads` from the UPDATE clause — those columns belong to the default-session writer; pre-existing values survive register-session calls.
+- **`trusted-memory/state-schema.md` — rewrite per `coding-policy: stateful-artifacts`.** Two-table contract: `trusted_sessions` (per-session metadata, PK on `session_name`) + `trusted_session_singleton` (CHECK(id=1) singleton with the back-compat `active_session_id` mirror and the JSON-blob payload columns owned by the default-session writer). Writer/reader contracts for the UPSERT + the `last_seen` stamp, concurrency rationale (PK + WAL retire the `session-state.json.lock` sidecar), bootstrap-sentinel carve-out, migration policy.
+- **`trusted-memory/SKILL.md` Step 7** — prose now describes the UPSERT into the two SQLite tables instead of the JSON envelope write. The "atomic tempfile+fsync+os.replace" ceremony language retires; the DB-write + sentinel-write transactionality boundary is preserved (DB row updated even if the sentinel write fails — same recovery path as before).
+- **`trusted-memory/SKILL.md` Bootstrap Error Handling** — split the JSON-era "missing / corrupt session-state.json" rows into two SQL-era rows: "no `trusted_sessions` row yet" (recoverable, next call establishes) vs "table missing / DB unreachable" (hard failure, points at orchestrator state-006 migration not having run).
+
+The admin-tile's heartbeat-precheck.py last-seen stamp + heartbeat/SKILL.md Hard Rules update for `trusted_sessions` / `trusted_session_singleton` ships in a separate PR (cross-tile work for `#298` requires one PR per repo).
+
+### Tests
+
+- **`tests/test_register_session.py` (rewrite)** — 6 cases pinning the SQLite contract: full roundtrip with both tables UPSERTed, missing $CLAUDE_SESSION_ID skips sentinel, empty `sessions` table records `session_id = NULL`, sibling session rows untouched (the JSON-era cross-session clobber bug retires by construction with PK on session_name), singleton UPSERT preserves `pending_response` / `muted_threads` (default-session writer's columns), DB unreachable → exit 1.
+
 ### Skills
 
 - **`system-status` SKILL.md content rewrite — finish #65** (`jbaruch/nanoclaw-admin#65`) — PR #14 (`d35ae5d`) shipped the directory rename, `tile.json` update, the new `scripts/system-status-checks.py`, and the test suite, but the new `skills/system-status/SKILL.md` was created with the **legacy content** verbatim — same `name: check-system-health` frontmatter, same three `python3 -c "..."` inline blocks the rewrite was supposed to remove. The CHANGELOG entry below describes the rewrite that PR #14 intended; this PR actually performs it: frontmatter `name` → `system-status`, body collapsed to Step 1 (run `system-status-checks.py`) / Step 2 (act on `alerts`), description tightened to read-only-trusted-tier scope, dismiss-mechanism section dropped (admin's domain), explicit "What this skill is NOT" section added. `tessl skill review skills/system-status` reports 100%.

--- a/skills/trusted-memory/SKILL.md
+++ b/skills/trusted-memory/SKILL.md
@@ -108,21 +108,21 @@ If bootstrap IS needed → run all steps below in order:
 4. Read the most recent 2 files from `/workspace/group/memory/weekly/` as summaries (older context).
 5. Read the most recent 2 files from `/workspace/trusted/memory/daily/` (cross-group shared memory).
 6. Read `/workspace/trusted/highlights.md` if it exists (major long-term events).
-7. Write session metadata into `session-state.json` under a per-session subtree. See `state-schema.md` for the on-disk shape and the legacy back-compat field. Current-session stamping:
+7. Write session metadata into the `trusted_sessions` + `trusted_session_singleton` SQLite tables in `/workspace/store/messages.db`. See `state-schema.md` for the column-level contract. Current-session stamping:
 
 ```
 python3 /home/node/.claude/skills/tessl__trusted-memory/scripts/register-session.py
 ```
 
-Reads `session_id` from `/workspace/store/messages.db`, stamps `sessions.<$NANOCLAW_SESSION_NAME>` and top-level `session_id` in `/workspace/group/session-state.json` (with `schema_version: 1` per `state-schema.md`), and writes the bootstrap sentinel at `/tmp/session_bootstrapped` with `$CLAUDE_SESSION_ID`. Both writes are individually atomic (tempfile + fsync + chmod-to-preserve-mode + os.replace), but the two-file sequence is NOT transactional: if the sentinel write fails after the state write succeeded, the state file is already updated and the next run will still re-bootstrap (because the sentinel is missing/stale). Steps 7 and the old Step 8 "write the sentinel" are both handled by this single invocation. Emits a single-line JSON status to stdout (`{"session_id": ..., "session_name": ..., "schema_version": 1, "wrote_state": true, "wrote_sentinel": <bool>}`); `wrote_sentinel` is `false` when `$CLAUDE_SESSION_ID` is missing/empty (deliberate skip per the sentinel-empty guard).
+Reads `session_id` from `messages.db`'s `sessions` table; UPSERTs the `trusted_sessions` row keyed on `$NANOCLAW_SESSION_NAME`; UPSERTs the `trusted_session_singleton` row (id=1) for the back-compat `active_session_id` mirror — both writes in a single SQL transaction. Per-session PK + per-id PK make sibling-row clobber impossible by construction; the JSON-era `LOCK_EX` + tempfile + fsync + `os.replace` ceremony retires. Then writes the bootstrap sentinel at `/tmp/session_bootstrapped` with `$CLAUDE_SESSION_ID` (still file-based — per-container, not shared state). The DB write and the sentinel write are NOT transactional together: if the sentinel write fails after the DB transaction committed, the DB row is already updated and the next run will still re-bootstrap (because the sentinel is missing/stale). Steps 7 and the old Step 8 "write the sentinel" are both handled by this single invocation. Emits a single-line JSON status to stdout (`{"session_id": ..., "session_name": ..., "schema_version": 1, "wrote_state": true, "wrote_sentinel": <bool>}`); `wrote_sentinel` is `false` when `$CLAUDE_SESSION_ID` is missing/empty (deliberate skip per the sentinel-empty guard).
 
 Total context budget for memory: ~3000 tokens. Summarize large files before loading.
 
 ### Bootstrap Error Handling
 
 - **Missing files**: Skip silently and continue. Do not treat absence as an error.
-- **Missing `session-state.json`**: Treat as a fresh session — proceed through all steps and create the file at step 7.
-- **Corrupt or unreadable `session-state.json`**: Treat as missing — overwrite with the current session ID after completing bootstrap.
+- **No `trusted_sessions` row yet (fresh DB, table present)**: Treat as a fresh session — proceed through all steps; Step 7's UPSERT establishes the row.
+- **`trusted_sessions` table missing / DB unreachable**: Hard failure — `register-session.py` exits 1, the bootstrap doesn't complete. Points at the orchestrator's state-006 migration not having run; verify the DB exists and has the `trusted_sessions` / `trusted_session_singleton` tables.
 - **Missing or empty daily/weekly directories**: Skip those steps and proceed. Note in the first rolling memory update that this is a new memory store.
 
 ## Rolling Memory Updates

--- a/skills/trusted-memory/scripts/register-session.py
+++ b/skills/trusted-memory/scripts/register-session.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Write session metadata into session-state.json and mark bootstrap done.
+"""Write session metadata into the trusted_sessions / trusted_session_
+singleton SQLite tables and mark bootstrap done.
 
 Usage:
     register-session.py
@@ -11,38 +12,40 @@ Reads:
     - Current session ID from `$CLAUDE_SESSION_ID` (for the bootstrap
       sentinel).
 
-Writes (both atomically, tempfile + fsync + os.replace):
-    - `/workspace/group/session-state.json` — updates
-      `sessions.<session_name>` with `{started, epoch, session_id,
-      last_seen}` and mirrors `session_id` at the top level for
-      back-compat.
-    - `/tmp/session_bootstrapped` — sentinel containing the current
+Writes (single SQLite transaction + sentinel file):
+    - `trusted_sessions` row keyed on `session_name` (UPSERT) with
+      `{started, epoch, session_id, last_seen}`.
+    - `trusted_session_singleton` (id=1, UPSERT) with
+      `active_session_id` mirrored at the top level for back-compat.
+    - `/tmp/session_bootstrapped` sentinel containing the current
       CLAUDE_SESSION_ID so `needs-bootstrap.py` reports "done" on
       subsequent runs. NOT written when CLAUDE_SESSION_ID is missing
       or empty — an empty sentinel would match an empty env on the
       next run and cause bootstrap to be skipped forever.
 
+Replaces the JSON-era `session-state.json` envelope read-modify-write
+that this script defended with `fcntl.LOCK_EX` + tempfile + fsync +
+`os.replace`. The PK on `session_name` makes per-session writes
+atomic — a concurrent writer for `default` and `maintenance` cannot
+clobber each other's columns. Sibling readers (heartbeat-precheck's
+last_seen stamp, check-email's seen-ids append) target their own
+tables; cross-writer interference is impossible by construction.
+
 Exit codes:
     0 — success (state written; sentinel skipped is still success
         when CLAUDE_SESSION_ID is empty/unset, with a stderr note)
-    1 — state file read/write failure
+    1 — DB / SQL / sentinel write failure (diagnostic on stderr)
 
-Note on sqlite behavior: the previous inline block would have raised
-on a missing messages.db or missing `sessions` table. This script
-intentionally catches `sqlite3.Error` broadly and treats it as
-`session_id=None` with a stderr note — a deliberate relaxation,
-not a behavior-preserving port, because bootstrap shouldn't hard-
-crash the whole memory-load flow when the DB is temporarily
-unreadable (locked, early-boot, etc.). The back-compat mirror still
-records `None`, which downstream consumers tolerate.
-
-Concurrency: state-file writes use an fcntl.LOCK_EX on
-`<STATE_PATH>.lock` around the read-modify-write cycle. heartbeat-
-precheck.py and check-email writers use the same lock file; without
-coordination a concurrent `last_seen` stamp or `pending_response`
-update can clobber this script's `sessions.<name>` write.
+Note on sqlite behavior: the script catches `sqlite3.Error` from the
+`sessions` read broadly and treats it as `session_id=None` — a
+deliberate relaxation, not a behavior-preserving port, because
+bootstrap shouldn't hard-crash the whole memory-load flow when the
+DB is temporarily unreadable (locked, early-boot, etc.). The trusted
+state UPSERT below uses the same DB connection and DOES exit 1 on
+failure — that's the load-bearing write.
 """
-import fcntl
+from __future__ import annotations
+
 import json
 import os
 import sqlite3
@@ -58,50 +61,31 @@ from typing import Optional
 # the bootstrap flow responsive while still riding out short contention.
 MESSAGES_DB_TIMEOUT_SECONDS = 10
 
-MESSAGES_DB = "/workspace/store/messages.db"
-STATE_PATH = "/workspace/group/session-state.json"
-STATE_LOCK_PATH = STATE_PATH + ".lock"
+DB_PATH = os.environ.get("ORDERS_DB_PATH", "/workspace/store/messages.db")
 SENTINEL = "/tmp/session_bootstrapped"
 
-# Bumped when the on-disk shape of session-state.json changes. v1 is the
-# current canonical shape (top-level `schema_version` + `sessions.<name>`
-# subtree + back-compat top-level `session_id`). Files written before
-# this field existed are read-tolerated below and silently upgraded to
-# v1 on the next write — owner-skill migration per
-# `jbaruch/coding-policy: stateful-artifacts`.
-STATE_SCHEMA_VERSION = 1
+# Bumped when the row shapes change; coordinated with state-006-trusted-
+# session-state.ts upstream.
+TRUSTED_SCHEMA_VERSION = 1
 
 
-def read_session_id_from_db() -> Optional[str]:
+def read_session_id_from_db(conn: sqlite3.Connection) -> Optional[str]:
+    """Best-effort read of the orchestrator's current session_id."""
     try:
-        conn = sqlite3.connect(MESSAGES_DB, timeout=MESSAGES_DB_TIMEOUT_SECONDS)
-        try:
-            row = conn.execute(
-                "SELECT session_id FROM sessions LIMIT 1"
-            ).fetchone()
-        finally:
-            conn.close()
+        row = conn.execute("SELECT session_id FROM sessions LIMIT 1").fetchone()
         return row[0] if row else None
     except sqlite3.Error as e:
         print(
-            f"register-session: cannot read session_id from {MESSAGES_DB}: {e}",
+            f"register-session: cannot read session_id from sessions table: {e}",
             file=sys.stderr,
         )
         return None
 
 
 def atomic_write_text(path: str, content: str, default_mode: int = 0o644) -> None:
-    """Atomically replace `path`'s contents with `content`.
-
-    Tempfile in the same directory → write → flush → fsync → chmod (to
-    the target's existing mode, or `default_mode` if creating fresh) →
-    os.replace. Cleans up the tempfile on any failure so a crash mid-
-    write doesn't leave a stray `*.tmp` orphan next to the target.
-
-    The chmod step matters: NamedTemporaryFile defaults to 0600, which
-    would silently narrow shared state files (e.g. /workspace/group/*)
-    on the first write unless preserved.
-    """
+    """Atomically replace `path`'s contents with `content`. Used only
+    for the `/tmp/session_bootstrapped` sentinel — the trusted state
+    is now in SQLite and uses a SQL transaction, not a file."""
     dir_ = os.path.dirname(path) or "."
     try:
         target_mode = os.stat(path).st_mode & 0o777
@@ -131,105 +115,60 @@ def atomic_write_text(path: str, content: str, default_mode: int = 0o644) -> Non
                 )
 
 
-def atomic_write_json(path: str, data: dict) -> None:
-    atomic_write_text(path, json.dumps(data, indent=2))
-
-
-def main() -> None:
-    session_id = read_session_id_from_db()
+def main() -> int:
     session_name = os.environ.get("NANOCLAW_SESSION_NAME", "default")
     claude_session_id = os.environ.get("CLAUDE_SESSION_ID", "")
+    now = datetime.now(timezone.utc)
+    now_iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    epoch = int(time.time())
 
-    # Hold LOCK_EX on STATE_LOCK_PATH for the entire read-modify-write
-    # cycle. Other writers on this file — heartbeat-precheck's
-    # last_seen stamp, check-email's seen_email_ids append, default-
-    # session pending_response/muted_threads updates — use (or will
-    # use) the same lock file. Without coordination, our sessions.<name>
-    # write can clobber a concurrent last_seen update, or vice versa.
-    # heartbeat-precheck.py documents the shared-lock convention.
+    conn = None
+    session_id: Optional[str] = None
     try:
-        lock_f = open(STATE_LOCK_PATH, "a+")
-    except OSError as e:
+        conn = sqlite3.connect(DB_PATH, timeout=MESSAGES_DB_TIMEOUT_SECONDS)
+        session_id = read_session_id_from_db(conn)
+
+        with conn:
+            # UPSERT the per-session row. PK on session_name makes this
+            # write atomic; sibling sessions (e.g. 'default' vs
+            # 'maintenance') are physically untouched.
+            conn.execute(
+                """
+                INSERT INTO trusted_sessions
+                  (session_name, session_id, started, epoch, last_seen)
+                  VALUES (?, ?, ?, ?, ?)
+                  ON CONFLICT(session_name) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    started    = excluded.started,
+                    epoch      = excluded.epoch,
+                    last_seen  = excluded.last_seen
+                """,
+                (session_name, session_id, now_iso, epoch, now_iso),
+            )
+            # UPSERT the singleton (id=1) with the back-compat
+            # `active_session_id` mirror. The CHECK(id=1) constraint
+            # makes the table genuinely single-row. `pending_response`
+            # and `muted_threads` are NOT in the column list — the
+            # default-session writer owns those columns; preserve any
+            # value already there.
+            conn.execute(
+                """
+                INSERT INTO trusted_session_singleton (id, active_session_id)
+                  VALUES (1, ?)
+                  ON CONFLICT(id) DO UPDATE SET
+                    active_session_id = excluded.active_session_id
+                """,
+                (session_id,),
+            )
+    except sqlite3.Error as e:
         print(
-            f"register-session: cannot open lock file {STATE_LOCK_PATH}: {e}",
+            f"register-session: SQLite error writing trusted state at {DB_PATH}: {e}",
             file=sys.stderr,
         )
-        sys.exit(1)
-
-    try:
-        fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
-
-        try:
-            with open(STATE_PATH) as f:
-                state = json.load(f)
-        except FileNotFoundError:
-            state = {}
-        except (json.JSONDecodeError, UnicodeDecodeError) as e:
-            # UnicodeDecodeError covers non-UTF-8 bytes (corruption/manual
-            # edit); treated like malformed JSON — start fresh with a
-            # stderr note rather than letting a traceback bubble up.
-            print(
-                f"register-session: state file malformed at {STATE_PATH}: {e}; starting fresh",
-                file=sys.stderr,
-            )
-            state = {}
-        except OSError as e:
-            # PermissionError, EIO, etc. — docstring promises exit 1 on
-            # any read failure.
-            print(
-                f"register-session: state file read failed at {STATE_PATH}: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        if not isinstance(state, dict):
-            print(
-                f"register-session: state file at {STATE_PATH} contained non-object JSON (type {type(state).__name__}); starting fresh",
-                file=sys.stderr,
-            )
-            state = {}
-
-        # setdefault("sessions", {}) doesn't guard against an existing but
-        # non-dict value (e.g. list/string) — state["sessions"][name] = ...
-        # below would crash with TypeError. Reset to {} with a stderr note
-        # if the shape is wrong.
-        if not isinstance(state.get("sessions"), dict):
-            if "sessions" in state:
-                print(
-                    f"register-session: state.sessions was not an object (type {type(state.get('sessions')).__name__}); resetting",
-                    file=sys.stderr,
-                )
-            state["sessions"] = {}
-        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        state["sessions"][session_name] = {
-            "started": now_iso,
-            "epoch": int(time.time()),
-            "session_id": session_id,
-            "last_seen": now_iso,
-        }
-        state["session_id"] = session_id  # back-compat; see PR #55
-        # Stamp schema_version last so it always reflects what this writer
-        # produces, even when starting from an unversioned legacy file.
-        state["schema_version"] = STATE_SCHEMA_VERSION
-
-        try:
-            atomic_write_json(STATE_PATH, state)
-        except OSError as e:
-            print(
-                f"register-session: failed to write {STATE_PATH}: {e}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        return 1
     finally:
-        # Lock released automatically when lock_f closes, but be
-        # explicit so the intent is obvious to readers.
-        try:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
-        except OSError:
-            # Already released or fd invalidated — lock_f.close() below
-            # handles the rest. Nothing actionable; skip the stderr.
-            pass
-        lock_f.close()
+        if conn is not None:
+            conn.close()
 
     # Refuse to write an empty sentinel. An empty string would match the
     # default `$CLAUDE_SESSION_ID` fallback in needs-bootstrap.py
@@ -243,7 +182,7 @@ def main() -> None:
             file=sys.stderr,
         )
         emit_status(session_id, session_name, wrote_sentinel=False)
-        return
+        return 0
 
     try:
         atomic_write_text(SENTINEL, claude_session_id)
@@ -252,9 +191,10 @@ def main() -> None:
             f"register-session: failed to write sentinel {SENTINEL}: {e}",
             file=sys.stderr,
         )
-        sys.exit(1)
+        return 1
 
     emit_status(session_id, session_name, wrote_sentinel=True)
+    return 0
 
 
 def emit_status(
@@ -272,7 +212,7 @@ def emit_status(
             {
                 "session_id": session_id,
                 "session_name": session_name,
-                "schema_version": STATE_SCHEMA_VERSION,
+                "schema_version": TRUSTED_SCHEMA_VERSION,
                 "wrote_state": True,
                 "wrote_sentinel": wrote_sentinel,
             }
@@ -281,4 +221,4 @@ def emit_status(
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/skills/trusted-memory/scripts/register-session.py
+++ b/skills/trusted-memory/scripts/register-session.py
@@ -122,6 +122,20 @@ def main() -> int:
     now_iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
     epoch = int(time.time())
 
+    # Hard-fail when the orchestrator DB is absent rather than letting
+    # `sqlite3.connect()` create an empty file (which would then error
+    # out on missing tables and leave a stray DB file behind). A
+    # missing DB points at the orchestrator's state-006 migration not
+    # having run; the operator needs that visible, not masked.
+    if not os.path.exists(DB_PATH):
+        print(
+            f"register-session: orchestrator DB not found at {DB_PATH}. "
+            "Verify the database file exists; if missing, the state-006 "
+            "migration may not have run.",
+            file=sys.stderr,
+        )
+        return 1
+
     conn = None
     session_id: Optional[str] = None
     try:
@@ -131,34 +145,50 @@ def main() -> int:
         with conn:
             # UPSERT the per-session row. PK on session_name makes this
             # write atomic; sibling sessions (e.g. 'default' vs
-            # 'maintenance') are physically untouched.
+            # 'maintenance') are physically untouched. `schema_version`
+            # is written on both insert and update so a future bump of
+            # TRUSTED_SCHEMA_VERSION self-heals existing rows on the
+            # next register-session call (the alternative — only on
+            # insert — would leave older rows at the prior version
+            # forever, defeating the "owner bumps schema_version"
+            # contract in state-schema.md).
             conn.execute(
                 """
                 INSERT INTO trusted_sessions
-                  (session_name, session_id, started, epoch, last_seen)
-                  VALUES (?, ?, ?, ?, ?)
+                  (session_name, session_id, started, epoch, last_seen, schema_version)
+                  VALUES (?, ?, ?, ?, ?, ?)
                   ON CONFLICT(session_name) DO UPDATE SET
-                    session_id = excluded.session_id,
-                    started    = excluded.started,
-                    epoch      = excluded.epoch,
-                    last_seen  = excluded.last_seen
+                    session_id     = excluded.session_id,
+                    started        = excluded.started,
+                    epoch          = excluded.epoch,
+                    last_seen      = excluded.last_seen,
+                    schema_version = excluded.schema_version
                 """,
-                (session_name, session_id, now_iso, epoch, now_iso),
+                (
+                    session_name,
+                    session_id,
+                    now_iso,
+                    epoch,
+                    now_iso,
+                    TRUSTED_SCHEMA_VERSION,
+                ),
             )
             # UPSERT the singleton (id=1) with the back-compat
             # `active_session_id` mirror. The CHECK(id=1) constraint
             # makes the table genuinely single-row. `pending_response`
             # and `muted_threads` are NOT in the column list — the
             # default-session writer owns those columns; preserve any
-            # value already there.
+            # value already there. `schema_version` self-heals via the
+            # same pattern as `trusted_sessions` above.
             conn.execute(
                 """
-                INSERT INTO trusted_session_singleton (id, active_session_id)
-                  VALUES (1, ?)
+                INSERT INTO trusted_session_singleton (id, active_session_id, schema_version)
+                  VALUES (1, ?, ?)
                   ON CONFLICT(id) DO UPDATE SET
-                    active_session_id = excluded.active_session_id
+                    active_session_id = excluded.active_session_id,
+                    schema_version    = excluded.schema_version
                 """,
-                (session_id,),
+                (session_id, TRUSTED_SCHEMA_VERSION),
             )
     except sqlite3.Error as e:
         print(
@@ -191,6 +221,11 @@ def main() -> int:
             f"register-session: failed to write sentinel {SENTINEL}: {e}",
             file=sys.stderr,
         )
+        # The DB transaction has already committed — emit status
+        # before exiting so callers expecting structured stdout can
+        # still see what was registered. The exit code remains the
+        # authoritative success signal.
+        emit_status(session_id, session_name, wrote_sentinel=False)
         return 1
 
     emit_status(session_id, session_name, wrote_sentinel=True)

--- a/skills/trusted-memory/state-schema.md
+++ b/skills/trusted-memory/state-schema.md
@@ -1,42 +1,84 @@
-# trusted-memory state schema
+# trusted-memory state schema (state-006, #298)
 
-State written by `scripts/register-session.py` per `jbaruch/coding-policy: stateful-artifacts`. Owner skill is `tessl__trusted-memory`. Reader skills (`heartbeat-precheck.py`, `check-email`) MUST treat any unrecognised shape as "no usable prior state" and let the next owner-skill run rewrite it.
+State written by `scripts/register-session.py` per `jbaruch/coding-policy: stateful-artifacts`. Owner skill is `tessl__trusted-memory`. Reader skills (`heartbeat-precheck.py`, `check-email` upstream) treat any unrecognised `schema_version` as "no usable prior state" and let the next owner-skill run rewrite it.
 
-## Files
+Post-`jbaruch/nanoclaw#298` the storage is two SQLite tables in `/workspace/store/messages.db`. The JSON-era `session-state.json` envelope retires, and so does the `fcntl.LOCK_EX + tempfile + fsync + os.replace` ceremony that defended it.
 
-### `/workspace/group/session-state.json`
+## Tables
 
-Mutable JSON object. Per-group, not shared across containers.
+### `trusted_sessions`
 
-```json
-{
-  "schema_version": 1,
-  "sessions": {
-    "<NANOCLAW_SESSION_NAME>": {
-      "started":    "<ISO-8601 UTC, e.g. 2026-04-27T15:00:00Z>",
-      "epoch":      <int unix seconds>,
-      "session_id": "<sqlite session_id from /workspace/store/messages.db, or null>",
-      "last_seen":  "<ISO-8601 UTC>"
-    }
-  },
-  "session_id": "<top-level mirror of the active session_id, back-compat>"
-}
+Per-session metadata. PK on `session_name` makes per-session writes atomic — the `default` session and the `maintenance` session cannot clobber each other's columns.
+
+| Column           | Type    | Nullable | Default             | Notes                                  |
+| ---------------- | ------- | -------- | ------------------- | -------------------------------------- |
+| `session_name`   | TEXT    | no       | —                   | PK; e.g. `default`, `maintenance`      |
+| `session_id`     | TEXT    | yes      | NULL                | from `messages.db.sessions`; nullable when SDK call hasn't completed yet |
+| `started`        | TEXT    | no       | —                   | UTC `Z`-suffixed ISO; cycle timestamp  |
+| `epoch`          | INTEGER | no       | —                   | Unix seconds at write time             |
+| `last_seen`      | TEXT    | no       | —                   | UTC `Z`-suffixed ISO; bumped on each register-session run + each heartbeat-precheck cycle |
+| `schema_version` | INTEGER | no       | `1`                 | Bumped on shape change; owner migrates |
+
+### `trusted_session_singleton`
+
+Single-row store for fields that aren't per-session: the back-compat `active_session_id` mirror and the JSON-blob payload columns owned by the default-session writer (`pending_response`, `muted_threads` — opaque to the schema, read/written verbatim by the owner).
+
+| Column              | Type    | Nullable | Default | Notes                                  |
+| ------------------- | ------- | -------- | ------- | -------------------------------------- |
+| `id`                | INTEGER | no       | —       | PK with `CHECK(id = 1)` — singleton    |
+| `active_session_id` | TEXT    | yes      | NULL    | Top-level back-compat mirror; written by `register-session.py` |
+| `pending_response`  | TEXT    | yes      | NULL    | JSON blob; default-session writer owns |
+| `muted_threads`     | TEXT    | yes      | NULL    | JSON blob; default-session writer owns |
+| `schema_version`    | INTEGER | no       | `1`     | Bumped on shape change                 |
+
+## Writer contracts
+
+`register-session.py` UPSERTs both tables in a single SQL transaction:
+
+```sql
+BEGIN;
+  INSERT INTO trusted_sessions
+    (session_name, session_id, started, epoch, last_seen)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(session_name) DO UPDATE SET
+      session_id = excluded.session_id,
+      started    = excluded.started,
+      epoch      = excluded.epoch,
+      last_seen  = excluded.last_seen;
+  INSERT INTO trusted_session_singleton (id, active_session_id)
+    VALUES (1, ?)
+    ON CONFLICT(id) DO UPDATE SET active_session_id = excluded.active_session_id;
+COMMIT;
 ```
 
-**Back-compat note (legacy migration, ex–`reference_session-state-migration.md`):** the top-level `session_id` field is the pre-`PR jbaruch/nanoclaw#55` shape, when only one session existed per group. It is still written so readers that haven't moved to the per-session subtree continue to work. New readers SHOULD use `sessions.<name>.session_id`. Old single-session files are accepted on read — register-session.py adds the `sessions` subtree without dropping the top-level field, so the migration is in-place and idempotent.
+The singleton UPSERT deliberately omits `pending_response` and `muted_threads` — those columns belong to the default-session writer; preserve any value already there. The CHECK(id=1) constraint makes the table genuinely single-row; an accidental `id=2` insert fails loudly with a constraint violation.
 
-**Other writers on this file** must take `fcntl.LOCK_EX` on `/workspace/group/session-state.json.lock` for the duration of their read-modify-write cycle. Current writers documented in `nanoclaw-admin/skills/heartbeat/scripts/heartbeat-precheck.py`. Without the shared lock, concurrent updates clobber each other.
+## Reader contracts
 
-### `/tmp/session_bootstrapped`
+`heartbeat-precheck.py` Section 5 / 5a stamp `last_seen` on the per-session row:
 
-Plain-text sentinel. One line: the value of `$CLAUDE_SESSION_ID` from the run that completed bootstrap.
+```sql
+UPDATE trusted_sessions
+   SET last_seen = ?     -- now UTC ISO-Z
+ WHERE session_name = ?;
+```
 
-`needs-bootstrap.py` compares this file's contents to the current `$CLAUDE_SESSION_ID`. Mismatch (or missing file) → bootstrap is needed. `register-session.py` REFUSES to write an empty sentinel because an empty value would match an empty env var on the next run and permanently suppress bootstrap.
+PK on `session_name` makes the UPDATE atomic; sibling sessions are physically untouched.
 
-## Schema versioning
+Per `coding-policy: stateful-artifacts`, reader skills don't migrate row shapes. On encountering an unfamiliar `schema_version`, a reader treats the row as "no usable prior state" and falls through to its safe default. Only the owner skill (`register-session.py`) bumps `schema_version`; readers stay version-locked until the owner ships an upgraded write.
 
-`session-state.json` carries `schema_version: 1` at the top level. v1 is the current canonical shape: `schema_version` + `sessions.<name>` subtree + back-compat top-level `session_id`. Files written before this field existed are read-tolerated by `register-session.py` (the owner skill) and silently upgraded to v1 on the next write — owner-skill migration per `jbaruch/coding-policy: stateful-artifacts`.
+## Concurrency
 
-Reader skills (`heartbeat-precheck.py`, `check-email/scripts/append-seen-ids.py`) MUST treat an unknown future version (`schema_version > 1`) as "no usable prior state" and let the next `register-session.py` run perform the upgrade — never migrate from a reader.
+The post-`#298` SQLite shape replaces the JSON-era `session-state.json.lock` sidecar entirely. SQLite's WAL + RESERVED-lock semantics serialise concurrent writers; the per-row PKs (`session_name` on `trusted_sessions`, `id` on the singleton) prevent cross-row clobber.
 
-`/tmp/session_bootstrapped` is a single-line plain-text sentinel; it has no envelope shape to version. The only behavioral contract is "non-empty content = bootstrap was completed for this `$CLAUDE_SESSION_ID`", and that contract is stable.
+Writers from other tables (`tz_state`, `follow_me_tasks`, `phase_completions`, `email_state`, `email_seen_ids`, `resumable_cycles`) target their own rows; sibling-table interference is impossible.
+
+## Bootstrap sentinel
+
+The `/tmp/session_bootstrapped` file remains file-based — it's a per-container sentinel, not shared state, so SQLite isn't the right tool. The atomic-write recipe (tempfile in same dir → flush → fsync → chmod-preserve → `os.replace`) for the sentinel is preserved in `register-session.py`. `needs-bootstrap.py` reads it via `open()` as before.
+
+## Migration policy
+
+- `schema_version` columns bump on every shape change.
+- Only `register-session.py` migrates row shapes.
+- Schema-level changes ship as a new state-NNN migration in `src/state-migrations/` upstream, with a corresponding bump to the relevant `schema_version` default.

--- a/tests/test_register_session.py
+++ b/tests/test_register_session.py
@@ -218,4 +218,8 @@ def test_db_unreachable_exits_1(register_session, monkeypatch, capsys):
 
     rc, _, err = _run(module, capsys)
     assert rc == 1
-    assert "SQLite error" in err or "trusted" in err.lower()
+    # Accept either "DB not found" (file-existence pre-check) or
+    # "SQLite error ..." (would-be tables-missing branch if the file
+    # somehow exists but is malformed). Both are exit-1 hard failures
+    # pointing at the orchestrator's state-006 migration not running.
+    assert "DB not found" in err or "SQLite error" in err or "trusted" in err.lower()

--- a/tests/test_register_session.py
+++ b/tests/test_register_session.py
@@ -1,15 +1,16 @@
-"""Baseline tests for skills/trusted-memory/scripts/register-session.py.
+"""Tests for skills/trusted-memory/scripts/register-session.py.
 
-Covers the documented contract:
-  - Reads session_id from /workspace/store/messages.db (sqlite3); tolerates
-    sqlite errors as session_id=None rather than crashing.
-  - Atomically writes session-state.json (sessions.<name> + back-compat
-    top-level session_id + schema_version).
-  - Atomically writes /tmp/session_bootstrapped sentinel — UNLESS
-    $CLAUDE_SESSION_ID is empty, in which case sentinel is skipped to
-    avoid a permanent bootstrap-skipped lockout.
-  - Emits a single-line JSON status to stdout per script-delegation rule.
+Post-#298 contract:
+  - Reads session_id from messages.db `sessions` table (best-effort)
+  - UPSERTs trusted_sessions row keyed on session_name
+  - UPSERTs trusted_session_singleton (id=1) for the back-compat
+    `active_session_id` mirror — does NOT touch pending_response /
+    muted_threads (default-session writer owns those columns)
+  - Sentinel write skipped on empty $CLAUDE_SESSION_ID
+  - Emits single-line JSON status to stdout
 """
+
+from __future__ import annotations
 
 import json
 import sqlite3
@@ -21,54 +22,91 @@ from .conftest import load_script
 SCRIPT_REL = "skills/trusted-memory/scripts/register-session.py"
 
 
-def _make_messages_db(path, session_id):
-    conn = sqlite3.connect(str(path))
-    conn.execute("CREATE TABLE sessions (session_id TEXT)")
-    if session_id is not None:
-        conn.execute("INSERT INTO sessions (session_id) VALUES (?)", (session_id,))
-    conn.commit()
-    conn.close()
+def _seed_db(db_path, session_id):
+    """Create messages.db with state-006 schema + the orchestrator's
+    `sessions` table (which register-session reads, not writes)."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (session_id TEXT);
+            CREATE TABLE trusted_sessions (
+              session_name   TEXT PRIMARY KEY,
+              session_id     TEXT,
+              started        TEXT NOT NULL,
+              epoch          INTEGER NOT NULL,
+              last_seen      TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE trusted_session_singleton (
+              id                INTEGER PRIMARY KEY CHECK(id = 1),
+              active_session_id TEXT,
+              pending_response  TEXT,
+              muted_threads     TEXT,
+              schema_version    INTEGER NOT NULL DEFAULT 1
+            );
+            """
+        )
+        if session_id is not None:
+            conn.execute("INSERT INTO sessions (session_id) VALUES (?)", (session_id,))
+        conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture
 def register_session(tmp_path, monkeypatch):
-    """Fresh module per test with all I/O paths redirected into tmp_path.
-    Caller is responsible for populating messages.db (or leaving it
-    missing for the sqlite-error path)."""
-    messages_db = tmp_path / "messages.db"
-    state_path = tmp_path / "session-state.json"
+    db_path = tmp_path / "messages.db"
     sentinel = tmp_path / "session_bootstrapped"
-
     module = load_script(f"register_session_{tmp_path.name}", SCRIPT_REL)
-    monkeypatch.setattr(module, "MESSAGES_DB", str(messages_db))
-    monkeypatch.setattr(module, "STATE_PATH", str(state_path))
-    monkeypatch.setattr(module, "STATE_LOCK_PATH", str(state_path) + ".lock")
+    monkeypatch.setattr(module, "DB_PATH", str(db_path))
     monkeypatch.setattr(module, "SENTINEL", str(sentinel))
+    return module, db_path, sentinel
 
-    return module, messages_db, state_path, sentinel
 
-
-def _run_and_capture(module, capsys):
-    """Run main(); return (exit_code or None, parsed_json_or_None)."""
+def _run(module, capsys):
     rc = None
     try:
-        module.main()
+        rc = module.main()
     except SystemExit as e:
         rc = e.code
-    captured = capsys.readouterr().out.strip()
-    payload = json.loads(captured.splitlines()[-1]) if captured else None
-    return rc, payload
+    captured = capsys.readouterr()
+    out = captured.out.strip()
+    payload = json.loads(out.splitlines()[-1]) if out else None
+    return rc, payload, captured.err
 
 
-def test_full_roundtrip_writes_state_and_sentinel(register_session, monkeypatch, capsys):
-    module, messages_db, state_path, sentinel = register_session
-    _make_messages_db(messages_db, "db-session-42")
+def _trusted_session(db_path, session_name):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT session_id, started, epoch, last_seen FROM trusted_sessions "
+            "WHERE session_name = ?",
+            (session_name,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _singleton(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT active_session_id, pending_response, muted_threads "
+            "FROM trusted_session_singleton WHERE id = 1"
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def test_full_roundtrip(register_session, monkeypatch, capsys):
+    module, db_path, sentinel = register_session
+    _seed_db(db_path, "db-session-42")
     monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-session-99")
     monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
 
-    rc, payload = _run_and_capture(module, capsys)
-
-    assert rc is None  # main() returns normally on success, no SystemExit
+    rc, payload, _ = _run(module, capsys)
+    assert rc == 0
     assert payload == {
         "session_id": "db-session-42",
         "session_name": "default",
@@ -76,77 +114,108 @@ def test_full_roundtrip_writes_state_and_sentinel(register_session, monkeypatch,
         "wrote_state": True,
         "wrote_sentinel": True,
     }
-    state = json.loads(state_path.read_text())
-    assert state["schema_version"] == 1
-    assert state["session_id"] == "db-session-42"
-    assert state["sessions"]["default"]["session_id"] == "db-session-42"
+    row = _trusted_session(db_path, "default")
+    assert row[0] == "db-session-42"  # session_id
+    assert row[2] > 0  # epoch
+    singleton = _singleton(db_path)
+    assert singleton[0] == "db-session-42"  # active_session_id
     assert sentinel.read_text() == "claude-session-99"
 
 
 def test_missing_claude_session_id_skips_sentinel(register_session, monkeypatch, capsys):
-    module, messages_db, state_path, sentinel = register_session
-    _make_messages_db(messages_db, "db-session-7")
+    module, db_path, sentinel = register_session
+    _seed_db(db_path, "db-session-7")
     monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
     monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
 
-    rc, payload = _run_and_capture(module, capsys)
-
-    assert rc is None
+    rc, payload, _ = _run(module, capsys)
+    assert rc == 0
     assert payload["wrote_state"] is True
     assert payload["wrote_sentinel"] is False
-    assert state_path.exists()
+    assert _trusted_session(db_path, "default") is not None
     assert not sentinel.exists()
 
 
-def test_sqlite_error_falls_back_to_null_session_id(register_session, monkeypatch, capsys):
-    module, messages_db, state_path, _sentinel = register_session
-    # messages.db intentionally not created — sqlite3.connect() will
-    # create an empty file, then the SELECT against a missing `sessions`
-    # table raises sqlite3.OperationalError (a subclass of sqlite3.Error).
-    monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-session-1")
-    monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
-
-    rc, payload = _run_and_capture(module, capsys)
-
-    assert rc is None
-    assert payload["session_id"] is None
-    assert payload["wrote_state"] is True
-    state = json.loads(state_path.read_text())
-    assert state["sessions"]["default"]["session_id"] is None
-    assert state["session_id"] is None
-
-
-def test_legacy_unversioned_state_upgrades_to_v1(register_session, monkeypatch, capsys):
-    module, messages_db, state_path, _sentinel = register_session
-    _make_messages_db(messages_db, "db-session-x")
-    # Pre-existing legacy file (pre-PR jbaruch/nanoclaw#55 shape) has
-    # only the top-level session_id and no `sessions` subtree, no
-    # schema_version field.
-    state_path.write_text(json.dumps({"session_id": "old-stamp"}))
-    monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-session-2")
-    monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
-
-    _run_and_capture(module, capsys)
-
-    state = json.loads(state_path.read_text())
-    assert state["schema_version"] == 1
-    assert state["sessions"]["default"]["session_id"] == "db-session-x"
-    # Top-level session_id is overwritten to current; legacy field
-    # stays present for back-compat readers per state-schema.md.
-    assert state["session_id"] == "db-session-x"
-
-
-def test_corrupt_state_json_starts_fresh(register_session, monkeypatch, capsys):
-    module, messages_db, state_path, _sentinel = register_session
-    _make_messages_db(messages_db, "db-session-y")
-    state_path.write_text("not json at all {{")
-    monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-session-3")
+def test_empty_sessions_table_records_none(register_session, monkeypatch, capsys):
+    """When messages.db has no `sessions` row yet, session_id is None
+    in the trusted_sessions row but the row is still inserted."""
+    module, db_path, _ = register_session
+    _seed_db(db_path, None)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "x")
     monkeypatch.setenv("NANOCLAW_SESSION_NAME", "maintenance")
 
-    rc, payload = _run_and_capture(module, capsys)
+    rc, payload, _ = _run(module, capsys)
+    assert rc == 0
+    assert payload["session_id"] is None
+    assert _trusted_session(db_path, "maintenance")[0] is None
 
-    assert rc is None
-    assert payload["wrote_state"] is True
-    state = json.loads(state_path.read_text())
-    assert state["schema_version"] == 1
-    assert "maintenance" in state["sessions"]
+
+def test_sibling_session_rows_untouched(register_session, monkeypatch, capsys):
+    """A 'default' UPSERT must not touch a pre-existing 'maintenance'
+    row — the JSON-era cross-session clobber bug retires by
+    construction with PK on session_name."""
+    module, db_path, _ = register_session
+    _seed_db(db_path, "db-session-42")
+    # Pre-existing maintenance row with a session_id that should
+    # survive the default-session call below.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO trusted_sessions "
+            "(session_name, session_id, started, epoch, last_seen) "
+            "VALUES ('maintenance', 'maint-id', '2026-04-29T00:00:00Z', 1, "
+            "'2026-04-29T00:00:00Z')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "x")
+    monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
+    _run(module, capsys)
+    # Maintenance row is pristine:
+    maint = _trusted_session(db_path, "maintenance")
+    assert maint[0] == "maint-id"
+    # Default row was inserted:
+    default = _trusted_session(db_path, "default")
+    assert default[0] == "db-session-42"
+
+
+def test_singleton_preserves_pending_response(register_session, monkeypatch, capsys):
+    """The default-session writer owns `pending_response` /
+    `muted_threads` columns. register-session.py only writes
+    `active_session_id`; pre-existing values in the other columns
+    must survive the UPSERT."""
+    module, db_path, _ = register_session
+    _seed_db(db_path, "db-session-42")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO trusted_session_singleton "
+            "(id, active_session_id, pending_response, muted_threads) "
+            "VALUES (1, 'old-active', 'baruch is asking', '[\"thread-a\"]')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "x")
+    monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
+    _run(module, capsys)
+
+    singleton = _singleton(db_path)
+    assert singleton[0] == "db-session-42"  # active_session_id updated
+    assert singleton[1] == "baruch is asking"  # pending_response preserved
+    assert singleton[2] == '["thread-a"]'  # muted_threads preserved
+
+
+def test_db_unreachable_exits_1(register_session, monkeypatch, capsys):
+    """A DB that doesn't exist OR has no trusted_* tables → exit 1."""
+    module, db_path, _ = register_session
+    # Don't seed — db_path doesn't exist.
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "x")
+    monkeypatch.setenv("NANOCLAW_SESSION_NAME", "default")
+
+    rc, _, err = _run(module, capsys)
+    assert rc == 1
+    assert "SQLite error" in err or "trusted" in err.lower()


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Closes the trusted-tile half of jbaruch/nanoclaw#298 (epic jbaruch/nanoclaw#293). The orchestrator's state-006 migration landed two new tables (\`trusted_sessions\`, \`trusted_session_singleton\`); this PR retires \`session-state.json\` consumers in the trusted tile.

## Why now

\`session-state.json\` was a multi-writer file: \`register-session.py\` wrote per-session subtree \`sessions.<name>\`, the heartbeat-precheck stamped \`last_seen\`, the default-session managed \`pending_response\` / \`muted_threads\`. All five writers shared one \`fcntl.LOCK_EX\` sidecar; cross-session clobber risk was the entire point of the lock. The state-006 split keys per-session metadata on \`session_name\` PK and per-singleton fields on \`id=1\` CHECK — sibling-row clobber is now structurally impossible.

## What's in scope (this PR)

- **\`trusted-memory/scripts/register-session.py\` rewrite** — collapses the JSON envelope read-modify-write to a single SQL transaction UPSERTing both tables. CLI surface and stdout JSON unchanged. The singleton UPSERT deliberately omits \`pending_response\` / \`muted_threads\` from the UPDATE clause (default-session writer's columns; pre-existing values must survive).
- **\`trusted-memory/state-schema.md\` rewrite** — full column-level contract, writer/reader contracts, concurrency rationale, bootstrap-sentinel carve-out, migration policy.
- **\`trusted-memory/SKILL.md\` Step 7 + Bootstrap Error Handling** — prose updated to describe the SQL transaction.
- **\`tests/test_register_session.py\` rewrite** — 6 cases pinning the SQLite contract.
- The \`/tmp/session_bootstrapped\` sentinel stays file-based — it's per-container, not shared state.

## What's out of scope (separate PR on admin tile)

- **\`heartbeat-precheck.py\` Section 5/5a (last-seen stamp)** — needs to read/write \`trusted_sessions.last_seen\` instead of \`session-state.json\`. Lives in nanoclaw-admin; cross-tile work needs one PR per repo.
- **\`heartbeat/SKILL.md\` Hard Rules** — "permitted state surfaces" list extension to call out \`trusted_sessions\` / \`trusted_session_singleton\`.

## Test plan

- [x] \`pytest tests/\` — 21 passed (6 new for register-session SQLite contract; rest unchanged)
- [x] \`python3 -m ruff check tests/\` clean
- [x] \`python3 -m ruff format --check tests/\` clean
- [x] Python syntax check on register-session.py (\`ast.parse\`)
- [ ] Production smoke: confirm a fresh container's bootstrap writes both \`trusted_sessions\` row + \`trusted_session_singleton\` mirror; confirm pending_response is preserved across a register-session call

🤖 Generated with [Claude Code](https://claude.com/claude-code)