### PR TITLE
docs(rules): drop check-unanswered heartbeat step (nanoclaw-core#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Rules
 
-- **`skill-dependencies.md` — drop `check-unanswered` heartbeat step** (`jbaruch/nanoclaw-core#38`). The heartbeat-flow list named `check-unanswered` as Step 0.7. With the skill removed in `jbaruch/nanoclaw-core#38`, the bullet is gone; the surrounding tz-sync / missed-tasks / heartbeat-checks bullets are unchanged.
+- **`skill-dependencies` — drop `check-unanswered` heartbeat step** (`jbaruch/nanoclaw-core#38`). The heartbeat-flow list in `rules/skill-dependencies.md` named `check-unanswered` as Step 0.7. With the skill removed in `jbaruch/nanoclaw-core#38`, the bullet is gone; the surrounding tz-sync / missed-tasks / heartbeat-checks bullets are unchanged.
 
 ### Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules
+
+- **`skill-dependencies.md` — drop `check-unanswered` heartbeat step** (`jbaruch/nanoclaw-core#38`). The heartbeat-flow list named `check-unanswered` as Step 0.7. With the skill removed in `jbaruch/nanoclaw-core#38`, the bullet is gone; the surrounding tz-sync / missed-tasks / heartbeat-checks bullets are unchanged.
+
 ### Skills
 
 - **`trusted-memory` `append-to-daily-log.py` follow-up — header fix + production overrides** — Two regressions in the originally-shipped helper (post-merge audit found via comparison with `nanoclaw-trusted#21`, the parallel implementation that didn't merge):

--- a/rules/skill-dependencies.md
+++ b/rules/skill-dependencies.md
@@ -9,8 +9,7 @@ Skills that invoke or depend on other skills. Read this to understand execution 
 ## Heartbeat (runs every 15 min)
 1. Calls `task-tz-sync` (Step 0.5) — detects timezone changes
 2. Checks `task-tz-state.json` for missed tasks (Step 0.6) — may invoke `morning-brief` or `nightly-housekeeping`
-3. Calls `check-unanswered` (Step 0.7) — scans for unreplied messages
-4. Runs `heartbeat-checks.py` script (Step 1) — system health checks directly via script
+3. Runs `heartbeat-checks.py` script (Step 1) — system health checks directly via script
 
 ## Morning Brief (runs daily, 8am local)
 1. Reads Google Calendar via Composio (Step 1)


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Companion to `jbaruch/nanoclaw-core#38` (skill deletion) and the matching `jbaruch/nanoclaw-admin` PR (heartbeat orchestration cleanup).

`rules/skill-dependencies.md`'s heartbeat-flow list named `check-unanswered` as Step 0.7. With the skill gone, that bullet is removed; the surrounding `task-tz-sync`, missed-tasks, and `heartbeat-checks.py` bullets are unchanged.

## Changes

- **`rules/skill-dependencies.md`** — drop the `check-unanswered` bullet from the Heartbeat list.
- **`CHANGELOG.md`** — under `## Unreleased / Rules`.

## Verification

- `python3 -m ruff check tests/` ✓
- `python3 -m ruff format --check tests/` ✓
- `python3 -m pytest` ✓ (38 passed).

Refs: `jbaruch/nanoclaw-core#38`