### PR TITLE
docs(rules): #183 migrate dual-handle + installed-content postmortems to docs/adr/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Rules
 
+- **identity-dual-handle / installed-content-immutable — migrate postmortems to `docs/adr/`** (`jbaruch/nanoclaw-admin#183`, umbrella `jbaruch/nanoclaw-admin#180` RULES.md diet) — Two always-loaded rules contained incident postmortem narratives that don't change runtime behavior — they exist as historical context for *why* the rule exists. Moving them to `docs/adr/` removes them from the agent prefix while preserving the institutional memory. Each rule keeps the imperative + 1–2 line anchor pointing to the ADR. Verbatim transfer; no spec content changes. Files: `docs/adr/2026-04-27-dual-handle-role-splitting.md`, `docs/adr/2026-04-25-installed-content-erofs.md`. Measured: identity-dual-handle drops 2,142 → 1,242 bytes (-900); installed-content-immutable drops 2,339 → 1,038 bytes (-1,301); combined -2,201 bytes from the trusted-tier prefix.
+
 - **`skill-dependencies` — drop `check-unanswered` heartbeat step** (`jbaruch/nanoclaw-core#38`). The heartbeat-flow list in `rules/skill-dependencies.md` named `check-unanswered` as Step 0.7. With the skill removed in `jbaruch/nanoclaw-core#38`, the bullet is gone; the surrounding tz-sync / missed-tasks / heartbeat-checks bullets are unchanged.
 
 ### Skills

--- a/docs/adr/2026-04-25-installed-content-erofs.md
+++ b/docs/adr/2026-04-25-installed-content-erofs.md
@@ -1,0 +1,27 @@
+# 2026-04-25 — Installed Content EROFS (jbaruch/nanoclaw#247)
+
+Reference for the read-only contract on `/home/node/.claude/skills/` and `/home/node/.claude/.tessl/` enforced by `rules/installed-content-immutable.md`.
+
+## Why the contract exists
+
+- Pre-fix, agents occasionally `Write`/`Edit` over their own installed `SKILL.md` files or rule markdowns in-place.
+- Changes never persisted past container restart (the orchestrator rebuilds `skills/` and `.tessl/` from the registry at the top of every spawn) but were live for the current container's lifetime.
+- A session could operate on monkey-patched content for minutes-to-hours, producing diagnoses that didn't match what the registry actually served.
+
+## How the kernel enforces it
+
+Two read-only bind-mounts layer on top of the writable `/home/node/.claude` parent. Writes against `skills/` or `.tessl/` return a standard `cannot create <path>: Read-only file system` error at the syscall level — the rejection is the contract, not a bug to work around.
+
+## How to actually change a skill or rule
+
+Modifications flow through the staging → promote → publish → update pipeline:
+
+1. Edit the skill or rule in NAS staging (`groups/<group>/staging/<tile>/skills/<name>/SKILL.md` or `.../rules/<name>.md`).
+2. Invoke `tessl__promote-tiles` (the same admin-side skill `no-orphan-tasks.md` references) targeting the right tile. The skill opens a tile-repo PR, summons Copilot, and iterates fixups via `push_staged_to_branch` until the PR merges.
+3. The tile's GHA `publish-tile.yml` patches the version and publishes to the tessl registry on merge.
+4. The next `./scripts/deploy.sh` runs `tessl update` and the new content lands at `/app/tessl-workspace/.tessl/tiles/...`.
+5. Each subsequent agent-container spawn sees the new content (orchestrator's per-spawn cpSync rebuilds `skills/` and `.tessl/` from the registry).
+
+## What stays writable
+
+The parent `/home/node/.claude/` mount stays writable. The SDK keeps writing to `projects/<slug>/<sessionId>.jsonl` (transcripts), `debug/`, `todos/`, `telemetry/`, `session-env/`, and `projects/<slug>/memory/` (auto-memory overlay, trusted/main only). Only `skills/` and `.tessl/` are read-only — the agent's own state surfaces are unaffected.

--- a/docs/adr/2026-04-27-dual-handle-role-splitting.md
+++ b/docs/adr/2026-04-27-dual-handle-role-splitting.md
@@ -1,6 +1,6 @@
 # 2026-04-27 — Dual-Handle Role-Splitting Incident
 
-Reference incident motivating the deploy-tier `rules/identity-dual-handle.md` companion to the abstract dual-handle invariant in `jbaruch/nanoclaw-core: rules/core-behavior.md`.
+Reference incident motivating the deploy-tier `rules/identity-dual-handle.md` companion to the abstract dual-handle invariant in the `jbaruch/nanoclaw-core` tile's `rules/core-behavior.md`.
 
 ## What happened
 

--- a/docs/adr/2026-04-27-dual-handle-role-splitting.md
+++ b/docs/adr/2026-04-27-dual-handle-role-splitting.md
@@ -1,0 +1,18 @@
+# 2026-04-27 — Dual-Handle Role-Splitting Incident
+
+Reference incident motivating the deploy-tier `rules/identity-dual-handle.md` companion to the abstract dual-handle invariant in `jbaruch/nanoclaw-core: rules/core-behavior.md`.
+
+## What happened
+
+- A debate-setup message addressed the agent by its display-name trigger, assigned debate positions to two other bots, and added a "you're the judge" instruction directed at the agent's Telegram `@username` — which is the SAME bot.
+- The agent parsed the two surface forms as separate addressees and took on both the debater AND the judge roles in one turn.
+- Owner correction confirmed the obvious: both handles point at the same bot.
+- The same dual-handle pattern re-triggered the same morning on a follow-up message, confirming the failure mode wasn't a one-off parser glitch.
+
+## Why this is in an ADR, not the rule
+
+The runtime gate ("collapse trigger and `@username` into one addressee; never split into multiple roles based on surface form") is a per-turn behavior the rule keeps. The narrative — debate-setup wording, two re-triggers same morning, owner-correction wording — was loaded into every spawn but only fires the agent's recognition once the gate is already engaged. The ADR keeps the institutional memory; the rule keeps the gate.
+
+## Companion mitigation outside the rule
+
+The runtime identity preamble (`buildIdentityPreamble` in `jbaruch/nanoclaw-public`, injected from `ASSISTANT_NAME` / `ASSISTANT_USERNAME`) prevents the *identity-theft* form of dual-handle confusion (an agent claiming an example handle as its own). It does not stop the *role-splitting* form documented here. Both mitigations exist; this ADR is the one that documents the role-splitting failure class.

--- a/rules/identity-dual-handle.md
+++ b/rules/identity-dual-handle.md
@@ -4,19 +4,11 @@ alwaysApply: true
 
 # Identity — Dual-Handle Reference Incident
 
-Companion to the abstract dual-handle invariant in the `jbaruch/nanoclaw-core` tile's `rules/core-behavior.md`. The invariant itself ("display-name trigger and Telegram `@username` refer to the same agent — never split yourself into multiple addressees based on surface form") lives in core; this file is the deploy-tier record of a concrete failure that motivated it.
+Companion to the abstract dual-handle invariant in the `jbaruch/nanoclaw-core` tile's `rules/core-behavior.md`. The invariant ("display-name trigger and Telegram `@username` refer to the same agent — never split yourself into multiple addressees based on surface form") lives in core; this file is the deploy-tier hook on a concrete failure that motivated it.
 
-## Why Record It
+## Reference incident — 2026-04-27
 
-- A short concrete failure makes the abstract rule easier to recognise in the wild — the moment a message lists the trigger AND the `@username` separately, this is the pattern to remember
-- The runtime identity preamble (`buildIdentityPreamble` in the `jbaruch/nanoclaw-public` repo, injected from `ASSISTANT_NAME` / `ASSISTANT_USERNAME` env vars) prevents the *identity-theft* form of this confusion (agent claiming an example handle as its own); it does not stop the *role-splitting* form (agent treating its two valid handles as two addressees). The role-splitting failure is what the rule and this incident document
-
-## Reference Incident — 2026-04-27
-
-- A debate-setup message addressed the agent by its display-name trigger, assigned debate positions to two other bots, and added a "you're the judge" instruction directed at the agent's Telegram `@username` — which is the SAME bot
-- The agent parsed the two surface forms as separate addressees and took on both the debater AND the judge roles in one turn
-- Owner correction confirmed the obvious: both handles point at the same bot
-- The same dual-handle pattern re-triggered the same morning on a follow-up message, confirming the failure mode wasn't a one-off parser glitch
+A debate-setup message addressed the agent by its display-name trigger and added a "you're the judge" instruction directed at the agent's Telegram `@username`. The agent took on both roles in one turn. Re-triggered same morning. Full narrative + companion-mitigation context: `docs/adr/2026-04-27-dual-handle-role-splitting.md`.
 
 ## How to Apply
 

--- a/rules/identity-dual-handle.md
+++ b/rules/identity-dual-handle.md
@@ -4,7 +4,7 @@ alwaysApply: true
 
 # Identity — Dual-Handle Reference Incident
 
-Companion to the abstract dual-handle invariant in the `jbaruch/nanoclaw-core` tile's `rules/core-behavior.md`. The invariant ("display-name trigger and Telegram `@username` refer to the same agent — never split yourself into multiple addressees based on surface form") lives in core; this file is the deploy-tier hook on a concrete failure that motivated it.
+Companion to the abstract dual-handle invariant in the `jbaruch/nanoclaw-core` tile's `rules/core-behavior.md`. The invariant ("display-name trigger and Telegram `@username` refer to the same agent — never split yourself into multiple addressees based on surface form") lives in core; this file is the deploy-tier record of a concrete failure that motivated it.
 
 ## Reference incident — 2026-04-27
 

--- a/rules/installed-content-immutable.md
+++ b/rules/installed-content-immutable.md
@@ -4,28 +4,8 @@ alwaysApply: true
 
 # Installed Content Is Immutable At Runtime
 
-Installed skills (`/home/node/.claude/skills/<name>/SKILL.md`) and per-tile rule markdowns (`/home/node/.claude/.tessl/...`) cannot be edited from inside the agent container. Two read-only bind-mounts layer on top of the writable `/home/node/.claude` parent; the kernel rejects writes to those subdirs at the syscall level (jbaruch/nanoclaw#247).
-
-## Why
-
-- Pre-fix, agents occasionally `Write`/`Edit` over their own installed `SKILL.md` files or rule markdowns in-place.
-- Changes never persisted past container restart (the orchestrator rebuilds `skills/` and `.tessl/` from the registry at the top of every spawn) but were live for the current container's lifetime.
-- A session could operate on monkey-patched content for minutes-to-hours, producing diagnoses that didn't match what the registry actually served.
+Installed skills (`/home/node/.claude/skills/<name>/SKILL.md`) and per-tile rule markdowns (`/home/node/.claude/.tessl/...`) cannot be edited from inside the agent container. Two read-only bind-mounts layer on top of the writable `/home/node/.claude` parent; the kernel rejects writes to those subdirs at the syscall level. A `Write` returns `cannot create <path>: Read-only file system` — that's the contract, not a bug. See `docs/adr/2026-04-25-installed-content-erofs.md` for the motivating incident (`jbaruch/nanoclaw#247`) and the staging → promote → publish → update pipeline that's the supported way to change a skill or rule.
 
 ## What's still writable
 
 The parent `/home/node/.claude/` mount stays writable. The SDK keeps writing to `projects/<slug>/<sessionId>.jsonl` (transcripts), `debug/`, `todos/`, `telemetry/`, `session-env/`, and `projects/<slug>/memory/` (auto-memory overlay, trusted/main only). Only `skills/` and `.tessl/` are read-only.
-
-## How to actually change a skill or rule
-
-Modifications flow through the staging → promote → publish → update pipeline:
-
-1. Edit the skill or rule in NAS staging (`groups/<group>/staging/<tile>/skills/<name>/SKILL.md` or `.../rules/<name>.md`).
-2. Invoke `tessl__promote-tiles` (the same admin-side skill `no-orphan-tasks.md` references) targeting the right tile. The skill opens a tile-repo PR, summons Copilot, and iterates fixups via `push_staged_to_branch` until the PR merges.
-3. The tile's GHA `publish-tile.yml` patches the version and publishes to the tessl registry on merge.
-4. The next `./scripts/deploy.sh` runs `tessl update` and the new content lands at `/app/tessl-workspace/.tessl/tiles/...`.
-5. Each subsequent agent-container spawn sees the new content (orchestrator's per-spawn cpSync rebuilds `skills/` and `.tessl/` from the registry).
-
-## What "EROFS" looks like in practice
-
-A `Write` against an installed skill returns the standard `cannot create <path>: Read-only file system` error from the shell. This is not a bug to work around — it's the contract. Go through the pipeline above instead.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

Sub-issue of \`jbaruch/nanoclaw-admin#180\` (RULES.md diet umbrella). Trusted-half of \`jbaruch/nanoclaw-admin#183\`. Core-half (context-recovery JCON tail) ships separately on \`jbaruch/nanoclaw-core\`.

## Summary

Two always-loaded trusted-tier rules carried incident postmortem narratives in the prefix loaded into every container spawn. The narratives don't change runtime behavior — they exist as historical context for *why* the rule exists. Moving them to \`docs/adr/\` preserves the institutional memory while shrinking the per-spawn prefix.

- \`docs/adr/2026-04-27-dual-handle-role-splitting.md\` (new) — 4-bullet reference incident from \`rules/identity-dual-handle.md\`.
- \`docs/adr/2026-04-25-installed-content-erofs.md\` (new) — \`Why\` postmortem + 5-step staging → promote → publish → update pipeline from \`rules/installed-content-immutable.md\`.

Each rule keeps its imperative (the per-turn behavior gate) and a 1–2 line anchor pointing to the ADR. Verbatim transfer; no spec content changes.

## Numbers

- \`identity-dual-handle\`: 2,142 → 1,242 bytes (**-900**, -42%).
- \`installed-content-immutable\`: 2,339 → 1,038 bytes (**-1,301**, -56%).
- Combined: **-2,201 bytes** from the trusted-tier prefix.
- Lint: \`installed-content-immutable\` drops to 258 front-loaded tokens; \`identity-dual-handle\` drops to 309. Both ADRs surface as orphaned in lint, expected per \`coding-policy: context-artifacts\` for non-manifest reference docs.

## Coordination with companion PR

The core-half (\`context-recovery\` post-compaction tail extraction) lands separately on \`jbaruch/nanoclaw-core\`. The umbrella issue's combined ~5K target spans both PRs; this PR delivers ~2.2K of that.

\`identity-dual-handle.md\` references \`jbaruch/nanoclaw-core: rules/core-behavior.md\`; that cross-tile pointer is unchanged. The dual-handle invariant lives in core (abstract), the deploy-tier hook (this rule) cites it.

## Risk

Verbatim transfer. The runtime gate (\"collapse trigger and \`@username\` into one addressee\" / \"installed content is read-only — go through staging → promote\") stays in the rules. Postmortem context is moved, not deleted; the ADRs are full prose copies of the moved sections plus a one-paragraph framing of why each lives in an ADR.

## Test plan

- [x] \`tessl tile lint .\` passes
- [x] \`wc -c\` confirms the rule trims
- [ ] Post-merge: confirm \`Review & Publish Tile\` succeeds and registry advances past 0.1.59
- [ ] Post-merge: confirm \`identity-dual-handle\` and \`installed-content-immutable\` retain their imperatives in compiled \`RULES.md\` on \`telegram_old-wtf\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)