### PR TITLE
chore(rules): drop 'very' from session-bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules — conciseness pass per `coding-policy: context-writing-style` (tier 3)
+
+- **session-bootstrap** — dropped the `VERY` intensifier from "YOUR VERY FIRST ACTION". `very` here was carrying no constraint; the directive is "first action".
+
 ### Rules — conciseness pass per `coding-policy: context-writing-style`
 
 Always-on rules are loaded into every agent invocation, so meta-justification prose and dated incident references inflate the per-invocation token budget for no operational gain. This pass strips that content while preserving the operative contracts. Cut content is archived here per the rule's "What to Cut → move to CHANGELOG" guidance.

--- a/rules/session-bootstrap.md
+++ b/rules/session-bootstrap.md
@@ -4,7 +4,7 @@ alwaysApply: true
 
 # Session Bootstrap — MANDATORY First Action
 
-**YOUR VERY FIRST ACTION in every new session — before responding to ANY message — is to run this Bash command:**
+**YOUR FIRST ACTION in every new session — before responding to ANY message — is to run this Bash command:**
 
 ```bash
 cat /tmp/session_bootstrapped 2>/dev/null


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Drop the `VERY` intensifier from "YOUR VERY FIRST ACTION" in `session-bootstrap.md`. The intensifier carries no constraint per `jbaruch/coding-policy: context-writing-style` "What to Cut → Intensifiers used as noise modifiers"; the directive is "first action".

Companion to merged `nanoclaw-trusted#46` (tier-1 conciseness pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)