### PR TITLE
chore: gate pyright diagnostics in CI at zero findings (#55)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Renewal mechanism for pinned dependencies per `jbaruch/coding-policy:
+# dependency-management` — every pinned dependency needs an automated
+# renewal path where a scanner supports the ecosystem. requirements-dev.txt
+# holds the exact-pinned dev toolchain (pytest, ruff, pyright); Dependabot
+# opens PRs to bump those pins as upstream releases land.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps-dev)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,13 @@ jobs:
           python -m ruff check tests/
           python -m ruff format --check tests/
 
+      # Type/diagnostics gate at zero findings per `jbaruch/coding-policy:
+      # language-diagnostics`. Scope is the whole repo (scripts + tests) via
+      # pyrightconfig.json — broader than ruff's tests-only scope — because the
+      # source-side findings are the point. Runs before pytest: static first,
+      # cheap, no fixture boot.
+      - name: Types (pyright)
+        run: python -m pyright
+
       - name: Pytest
         run: python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
      them before publishing — do not add it manually (jbaruch/coding-policy:
      context-artifacts). -->
 
+### CI — gate pyright diagnostics at zero findings (`#55`)
+
+Adopts `jbaruch/coding-policy: language-diagnostics` for this Python tile, which previously ran only `ruff` (format/lint, scoped to `tests/`) with no type/diagnostics gate. New `pyrightconfig.json` resolves the skill-bundle `sys.path.insert` layout via per-bundle `executionEnvironments` (each `skills/*/scripts` dir is its own root so `memory_write` resolves within `trusted-memory`; `tests/` gets both bundles on `extraPaths`) — the layout from `jbaruch/nanoclaw-travel#81`. A first-ever pyright run (`typeCheckingMode: standard`) surfaced 47 findings; all fixed at the source with no blanket `# type: ignore` / `# pyright: basic` suppression.
+
+Four were real source-side holes: `__doc__.split("\n\n")[0]` in three argparse descriptions (`__doc__` is `str | None`, crashes if a module ever loses its docstring) now guard with `(__doc__ or "")`; `append-to-daily-log.py`'s `--lines-file` read had `raw` possibly-unbound because pyright doesn't model `argparse.error()` as `NoReturn` — an explicit `raise` after `parser.error()` states the abort invariant visibly. The 43 test findings were resolved with typed helpers per the rule's guidance (assert-not-None readers over scattered ignores): the `_run`/`_run_and_capture` capsys helpers return `{}` rather than `None` on empty stdout (narrowing 33 Optional-subscripts on `payload[...]`; no caller distinguished the `None` case), `conftest.load_script` and a self-contained `test_memory_write._load_memory_write` assert `spec`/`spec.loader` are non-None (`spec_from_file_location` returns `ModuleSpec | None`), and `os.kill` is guarded by `assert proc.pid is not None` (`Process.pid` is `int | None` before start).
+
+`pyright==1.1.408` pinned in `requirements-dev.txt` (pyright is version-sensitive; the pin is the exact version the zero-findings result was verified against) and wired into `test.yml` as a `Types (pyright)` step before pytest, alongside the existing `ruff` step. Pyright's scope is the whole repo (scripts + tests), deliberately broader than ruff's tests-only scope, since the source-side findings are the point of the rule.
+
 ## 0.1.78 — 2026-06-24
 
 ### Skills — document canonical `## Addresses` block in `user_profile.md` (`#53`)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,16 @@
+{
+  "pythonVersion": "3.11",
+  "typeCheckingMode": "standard",
+  "executionEnvironments": [
+    { "root": "skills/trusted-memory/scripts" },
+    { "root": "skills/system-status/scripts" },
+    {
+      "root": "tests",
+      "extraPaths": [
+        "skills/trusted-memory/scripts",
+        "skills/system-status/scripts"
+      ]
+    },
+    { "root": "." }
+  ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest==8.3.4
 ruff==0.7.4
+pyright==1.1.408

--- a/skills/system-status/scripts/system-status-checks.py
+++ b/skills/system-status/scripts/system-status-checks.py
@@ -115,7 +115,7 @@ def _query_recent_failures(conn: sqlite3.Connection) -> list[dict]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").split("\n\n")[0])
     parser.add_argument("--db", default="/workspace/store/messages.db")
     parser.add_argument("--stuck-grace-minutes", type=int, default=5)
     parser.add_argument("--message-row-warn", type=int, default=100_000)

--- a/skills/trusted-memory/scripts/append-daily-discovery.py
+++ b/skills/trusted-memory/scripts/append-daily-discovery.py
@@ -163,7 +163,7 @@ def _append(*, target: Path, block: str) -> dict:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description=__doc__.split("\n\n")[0],
+        description=(__doc__ or "").split("\n\n")[0],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--what", required=True)

--- a/skills/trusted-memory/scripts/append-to-daily-log.py
+++ b/skills/trusted-memory/scripts/append-to-daily-log.py
@@ -190,6 +190,7 @@ def _collect_lines(args, parser) -> List[str]:
             parser.error(
                 f"cannot read --lines-file {args.lines_file!r}: " f"{type(exc).__name__}: {exc}"
             )
+            raise  # unreachable: parser.error() exits; makes the abort explicit to the type checker
         lines = [ln for ln in raw.splitlines() if ln.strip()]
     elif args.line:
         # `--line` is `action="append"` so it's already a list.
@@ -273,7 +274,7 @@ def _append(*, daily_file: Path, lines: List[str]) -> dict:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
-        description=__doc__.split("\n\n")[0],
+        description=(__doc__ or "").split("\n\n")[0],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--target", required=True, choices=("group", "trusted"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def load_script(name: str, relpath: str):
     call so each test can monkeypatch the module-level constants
     without leaking state across tests."""
     spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relpath)
+    assert spec is not None and spec.loader is not None, f"cannot load spec for {relpath}"
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_append_daily_discovery.py
+++ b/tests/test_append_daily_discovery.py
@@ -48,7 +48,7 @@ def _run(module, argv, capsys, *, stdin_text=None):
     else:
         rc = module.main(argv)
     captured = capsys.readouterr()
-    payload = json.loads(captured.out.strip().splitlines()[-1]) if captured.out.strip() else None
+    payload = json.loads(captured.out.strip().splitlines()[-1]) if captured.out.strip() else {}
     return rc, payload, captured.err
 
 

--- a/tests/test_append_to_daily_log.py
+++ b/tests/test_append_to_daily_log.py
@@ -56,7 +56,10 @@ def append_module(tmp_path, monkeypatch):
 
 
 def _run(module, argv, capsys, stdin_text=None):
-    """Invoke main(argv); return (rc, payload, stderr)."""
+    """Invoke main(argv); return (rc, payload, stderr).
+
+    payload is the parsed last JSON line, or an empty dict when the
+    command produced no stdout (no caller distinguishes the two)."""
     if stdin_text is not None:
         original = sys.stdin
         from io import StringIO
@@ -69,7 +72,7 @@ def _run(module, argv, capsys, stdin_text=None):
     else:
         rc = module.main(argv)
     captured = capsys.readouterr()
-    payload = json.loads(captured.out.strip().splitlines()[-1]) if captured.out.strip() else None
+    payload = json.loads(captured.out.strip().splitlines()[-1]) if captured.out.strip() else {}
     return rc, payload, captured.err
 
 
@@ -82,7 +85,7 @@ def test_dedup_skips_existing_line(append_module, capsys):
     daily_file = group_dir / "2026-05-01.md"
     daily_file.parent.mkdir(parents=True, exist_ok=True)
     daily_file.write_text(
-        "# Daily Summary — 2026-05-01\n\n" "- 09:00 UTC — alpha\n" "- 10:00 UTC — beta\n"
+        "# Daily Summary — 2026-05-01\n\n- 09:00 UTC — alpha\n- 10:00 UTC — beta\n"
     )
     pre_mtime = daily_file.stat().st_mtime_ns
     pre_inode = daily_file.stat().st_ino

--- a/tests/test_memory_write.py
+++ b/tests/test_memory_write.py
@@ -23,13 +23,22 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HELPER_PATH = REPO_ROOT / "skills/trusted-memory/scripts/memory_write.py"
 
 
-@pytest.fixture
-def mw():
-    """Fresh module per test so monkeypatches don't bleed across cases."""
-    spec = importlib.util.spec_from_file_location("memory_write_under_test", HELPER_PATH)
+def _load_memory_write(module_name: str):
+    """Load memory_write.py under a unique module name.
+
+    Self-contained (not conftest.load_script) so it also works inside
+    the spawned child process in the crash-atomicity test."""
+    spec = importlib.util.spec_from_file_location(module_name, HELPER_PATH)
+    assert spec is not None and spec.loader is not None, "cannot load memory_write spec"
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.fixture
+def mw():
+    """Fresh module per test so monkeypatches don't bleed across cases."""
+    return _load_memory_write("memory_write_under_test")
 
 
 def test_normalize_collapses_whitespace_runs(mw):
@@ -78,17 +87,11 @@ def test_dedup_filter_block_granularity(mw):
     )
     # Same block, identical text — must dedup.
     dup_block = (
-        "## 2026-05-21 09:00 UTC\n"
-        "**What:** thing\n"
-        "**Context:** somewhere\n"
-        "**Promote to:** unsure\n"
+        "## 2026-05-21 09:00 UTC\n**What:** thing\n**Context:** somewhere\n**Promote to:** unsure\n"
     )
     # Different timestamp = different entry; must keep.
     new_block = (
-        "## 2026-05-21 10:00 UTC\n"
-        "**What:** thing\n"
-        "**Context:** somewhere\n"
-        "**Promote to:** unsure\n"
+        "## 2026-05-21 10:00 UTC\n**What:** thing\n**Context:** somewhere\n**Promote to:** unsure\n"
     )
     kept, dropped = mw.dedup_filter(existing, [dup_block, new_block], split="\n\n")
     assert kept == [new_block]
@@ -211,9 +214,7 @@ def _child_writer(target_path: str, ready_event, hold_event) -> None:
     `real_replace` unless the parent fails to kill it within
     `hold_event.wait()`'s timeout, in which case the test fails on
     `exitcode` rather than racing the timing."""
-    spec = importlib.util.spec_from_file_location("memory_write_child", HELPER_PATH)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    module = _load_memory_write("memory_write_child")
 
     real_replace = os.replace
 
@@ -270,6 +271,7 @@ def test_atomic_write_smoke_kill_mid_write_leaves_file_intact(tmp_path):
         "child never entered gated_replace; mkstemp/fsync likely failed "
         "before reaching the os.replace seam — check stderr from the child"
     )
+    assert proc.pid is not None  # started (ready_event fired), so pid is assigned
     os.kill(proc.pid, signal.SIGKILL)
     proc.join(timeout=5)
 

--- a/tests/test_register_session.py
+++ b/tests/test_register_session.py
@@ -56,7 +56,7 @@ def _run_and_capture(module, capsys):
     except SystemExit as e:
         rc = e.code
     captured = capsys.readouterr().out.strip()
-    payload = json.loads(captured.splitlines()[-1]) if captured else None
+    payload = json.loads(captured.splitlines()[-1]) if captured else {}
     return rc, payload
 
 


### PR DESCRIPTION
Closes #55. Adopts `jbaruch/coding-policy: language-diagnostics` for this Python tile — previously CI ran only `ruff` (tests-only) with no type/diagnostics gate.

## What

- **`pyrightconfig.json`** — resolves the skill-bundle `sys.path.insert` layout via per-bundle `executionEnvironments` (each `skills/*/scripts` dir is its own root so `memory_write` resolves within `trusted-memory`; `tests/` gets both bundles on `extraPaths`). Layout from `jbaruch/nanoclaw-travel#81`.
- **47 findings fixed at source** (`typeCheckingMode: standard`), no blanket `# type: ignore` / `# pyright: basic`.
- **CI gate** — `pyright==1.1.408` pinned in `requirements-dev.txt`, wired into `test.yml` as a `Types (pyright)` step before pytest, alongside ruff.

## The 4 real source-side findings

| File | Finding | Fix |
|---|---|---|
| 3 scripts | `__doc__.split(...)` — `__doc__` is `str \| None`, crashes if a module loses its docstring | guard `(__doc__ or "")` |
| `append-to-daily-log.py` | `raw` possibly-unbound (pyright doesn't model `argparse.error()` as `NoReturn`) | explicit `raise` after `parser.error()` states the abort invariant |

## The 43 test findings — typed helpers, not suppressions

- `_run`/`_run_and_capture` return `{}` not `None` on empty stdout → narrows 33 Optional-subscripts on `payload[...]` (no caller used the `None` case).
- `conftest.load_script` + `test_memory_write._load_memory_write` assert `spec`/`spec.loader` are non-None (`spec_from_file_location` returns `ModuleSpec | None`).
- `assert proc.pid is not None` before `os.kill` (`Process.pid` is `int \| None` pre-start).

## Scope note

Pyright scopes to the **whole repo** (scripts + tests), deliberately broader than ruff's tests-only scope — the source-side findings are the point of the rule. Documented in the CI step comment and CHANGELOG.

## Verification (all green locally)

- `ruff check` + `format --check` — clean
- `python -m pyright` (clean venv, pinned) — `0 errors, 0 warnings, 0 informations`
- `pytest` — 69 passed

CHANGELOG entry added as an un-headed `###` block; the stamp-changelog step versions it on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)