### PR TITLE
chore(gitignore): ignore tessl consumer-side scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,24 @@ Thumbs.db
 .idea/
 *.swp
 *~
+
+# Secrets — never committed
+.env
+.env.local
+
+# Tessl consumer-side scaffolding (dev-time local install via `tessl install`).
+# The tile itself ships from tile.json; coding-policy is pulled at scaffold
+# time for the install-reviewer skill, not committed. Matches the
+# `nanoclaw-core` public-tile pattern (no committed `.tessl/`, `tessl.json`,
+# or agent-rule pointer files).
+tessl.json
+.tessl/
+.claude/
+.agents/
+.codex/
+.gemini/
+.mcp.json
+AGENTS.md
+CLAUDE.md
+.github/skills/
+.github/mcp.json


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- Adds the fleet-standard "Tessl consumer-side scaffolding" ignore block (tessl.json, .tessl/, agent MCP configs, rule pointer files) that this repo was missing, matching the nanoclaw-media/travel/conferences pattern.
- Extends the block with `.github/mcp.json`, which current tessl CLI init emits and the existing fleet block predates.

## Test plan
- [ ] `git status` after `tessl install` in a fresh clone shows a clean tree
- [ ] CI green