### PR TITLE
fix(system-status): reconcile messages-db schema rule with production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
      them before publishing — do not add it manually (jbaruch/coding-policy:
      context-artifacts). -->
 
+### Fix — reconcile `messages-db-schema` rule with its consumers; repair recent-failures probe (`#69`)
+
+`rules/messages-db-schema.md` omitted two tables shipped scripts rely on:
+`sessions` (read by `register-session.py`) and `task_run_logs` (read by
+`system-status-checks.py`). Both are now documented with columns verified
+against the live host DB (2026-07-07). The verification surfaced a real
+production bug: the recent-failures probe selected a `last_result` column
+that doesn't exist on `task_run_logs` — every production run raised
+`OperationalError` (surfaced only as a query-failed alert), so task-failure
+detection was silently broken; its 24h window also compared ISO-8601 `T`/`Z`
+`run_at` values against SQLite `datetime('now')` output. The probe now
+filters `status IN ('error','killed')`, summarizes from
+`coalesce(error, result)`, and takes the cutoff as a matching ISO string
+computed in Python (new `--now-utc` test seam). `sessions` is keyed by
+(`group_folder`, `session_name`); `register-session.py`'s single-row
+`LIMIT 1` assumption is documented at the query site. Test fixtures for both
+consumers now build the production table shapes so future schema drift fails
+in tests.
+
 ## 0.1.85 — 2026-07-07
 
 ### Fix — harden `append-daily-discovery.py` input validation and dedup key (`#65`, `#66`)

--- a/rules/messages-db-schema.md
+++ b/rules/messages-db-schema.md
@@ -12,6 +12,7 @@ The shared SQLite at `/workspace/store/messages.db` is accessed via `python3 -c 
 - `trigger_word` — the actual column is `trigger_pattern`
 - `chat_jid` on `registered_groups` — it's not a column there; only on `messages`
 - `trusted` as a column — lives inside `container_config` JSON, not its own column
+- `last_result` on `task_run_logs` — that column lives on `scheduled_tasks`; `task_run_logs` carries `status`, `result`, `error`
 
 ## Tables
 
@@ -22,6 +23,8 @@ The shared SQLite at `/workspace/store/messages.db` is accessed via `python3 -c 
 - **`tz_state`** (singleton, `id = 1`): `id`, `current_tz`, `home_tz`, `scheduler_tz`, `schema_version`.
 - **`follow_me_tasks`**: `name` (PK), `local_time`, `schedule_value`, `last_run_date`, `pending_run_at`, `schema_version`, `updated_at`.
 - **`phase_completions`**: `phase` (PK), `last_completed`, `metadata`, `updated_at`, `schema_version`.
+- **`sessions`**: `group_folder`, `session_name` (default `'default'`), `session_id`. Composite PK (`group_folder`, `session_name`) — one row per group session, NOT a singleton. A bare `LIMIT 1` without `WHERE` returns an arbitrary group's row once more than one group has a session; `register-session.py` documents its single-row assumption inline.
+- **`task_run_logs`**: `id` (PK autoincrement), `task_id` (FK → `scheduled_tasks.id`), `run_at`, `duration_ms`, `status`, `result`, `error`. There is no `last_result` column — that name belongs on `scheduled_tasks`. `run_at` is ISO-8601 with `T` and `Z` (`2026-07-07T21:18:12.277Z`), NOT SQLite's `datetime('now')` shape — compare against a matching ISO string, never against `datetime(...)` output. Observed `status` values: `success`, `error`, `killed`, `precheck_skipped`.
 
 ## Prefer MCP Tools for Mutations
 

--- a/skills/system-status/scripts/system-status-checks.py
+++ b/skills/system-status/scripts/system-status-checks.py
@@ -30,9 +30,13 @@ Usage:
                             [--message-row-warn <int>]
                             [--task-log-row-warn <int>]
                             [--db-size-mb-warn <int>]
+                            [--now-utc <YYYY-MM-DDTHH:MM:SSZ>]
 
     --db                   Path to the messages.db (default
                            `/workspace/store/messages.db`).
+    --now-utc              Reference time override for the
+                           recent-failures window (test seam);
+                           defaults to now UTC.
     --stuck-grace-minutes  How long past `next_run` an active task
                            must be to count as stuck. Default 5.
                            Mirrors the prior inline check.
@@ -72,7 +76,7 @@ import json
 import os
 import sqlite3
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 
 def _now_iso() -> str:
@@ -97,17 +101,35 @@ def _query_row_counts(conn: sqlite3.Connection) -> dict[str, int]:
     return {"messages": msgs, "task_run_logs": logs}
 
 
-def _query_recent_failures(conn: sqlite3.Connection) -> list[dict]:
+def _failure_cutoff_iso(now: datetime) -> str:
+    """24h-ago cutoff in the same ISO-8601 `T`/`Z` shape the host
+    writes to `task_run_logs.run_at` (`2026-07-07T21:18:12.277Z`).
+    SQLite's `datetime('now', ...)` output uses a space separator and
+    compares incorrectly against that shape, so the cutoff is computed
+    here and passed as a parameter."""
+    return (now - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _query_recent_failures(
+    conn: sqlite3.Connection, cutoff_iso: str
+) -> list[dict]:
     """Failures within the last 24h. The dismiss file lives in admin's
     domain and is NOT consulted here; trusted reports verbatim and
-    the operator decides what to do (per the SKILL.md contract)."""
+    the operator decides what to do (per the SKILL.md contract).
+
+    `task_run_logs` columns per `rules/messages-db-schema.md`:
+    `status` (`success` / `error` / `killed` / `precheck_skipped`),
+    `error`, `result` — there is no `last_result` column. A failure is
+    a run with status `error` or `killed`; the summary prefers `error`
+    and falls back to `result`."""
     rows = conn.execute(
-        "SELECT task_id, run_at, substr(coalesce(last_result, ''), 1, 200) "
+        "SELECT task_id, run_at, substr(coalesce(error, result, ''), 1, 200) "
         "FROM task_run_logs "
-        "WHERE run_at >= datetime('now', '-24 hours') "
-        "  AND coalesce(last_result, '') LIKE '%error%' "
+        "WHERE run_at >= ? "
+        "  AND status IN ('error', 'killed') "
         "ORDER BY run_at DESC "
-        "LIMIT 20"
+        "LIMIT 20",
+        (cutoff_iso,),
     ).fetchall()
     return [
         {"task_id": r[0], "run_at": r[1], "error_summary": r[2]} for r in rows
@@ -121,7 +143,26 @@ def main() -> int:
     parser.add_argument("--message-row-warn", type=int, default=100_000)
     parser.add_argument("--task-log-row-warn", type=int, default=10_000)
     parser.add_argument("--db-size-mb-warn", type=int, default=500)
+    parser.add_argument(
+        "--now-utc",
+        help=(
+            "reference time override `YYYY-MM-DDTHH:MM:SSZ` for the "
+            "recent-failures window (test seam); defaults to now UTC"
+        ),
+    )
     args = parser.parse_args()
+
+    if args.now_utc:
+        try:
+            now = datetime.strptime(args.now_utc, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            parser.error(
+                f"--now-utc {args.now_utc!r} must match `YYYY-MM-DDTHH:MM:SSZ`"
+            )
+    else:
+        now = datetime.now(timezone.utc)
 
     payload: dict = {
         "checked_at": _now_iso(),
@@ -172,7 +213,9 @@ def main() -> int:
             payload["alerts"].append(f"row-counts query failed: {e}")
         queries_attempted += 1
         try:
-            payload["recent_failures"] = _query_recent_failures(conn)
+            payload["recent_failures"] = _query_recent_failures(
+                conn, _failure_cutoff_iso(now)
+            )
             queries_succeeded += 1
         except sqlite3.Error as e:
             payload["alerts"].append(f"recent-failures query failed: {e}")

--- a/skills/trusted-memory/scripts/register-session.py
+++ b/skills/trusted-memory/scripts/register-session.py
@@ -7,6 +7,9 @@ Usage:
 Reads:
     - Session ID from `/workspace/store/messages.db` (`sessions` table,
       first row). Falls back to `None` when the table is empty.
+      `sessions` is keyed by (`group_folder`, `session_name`) — see
+      `rules/messages-db-schema.md`; the single-row assumption behind
+      "first row" is documented at the query site below.
     - Session name from `$NANOCLAW_SESSION_NAME` (defaults to `default`).
     - Current session ID from `$CLAUDE_SESSION_ID` (for the bootstrap
       sentinel).
@@ -85,6 +88,14 @@ def read_session_id_from_db() -> Optional[str]:
     try:
         conn = sqlite3.connect(MESSAGES_DB, timeout=MESSAGES_DB_TIMEOUT_SECONDS)
         try:
+            # `sessions` is keyed by (group_folder, session_name), one
+            # row per group session (rules/messages-db-schema.md). The
+            # host currently writes a single row — the main group's
+            # session, which is the container this script runs in — so
+            # a bare LIMIT 1 is deterministic today. If the host starts
+            # registering sessions for other groups, this query must
+            # gain a WHERE on this container's group_folder; there is
+            # no container-side way to derive that folder name yet.
             row = conn.execute(
                 "SELECT session_id FROM sessions LIMIT 1"
             ).fetchone()

--- a/tests/test_register_session.py
+++ b/tests/test_register_session.py
@@ -22,10 +22,24 @@ SCRIPT_REL = "skills/trusted-memory/scripts/register-session.py"
 
 
 def _make_messages_db(path, session_id):
+    """Production shape of `sessions` per `rules/messages-db-schema.md`
+    (verified against the live host DB): keyed by
+    (`group_folder`, `session_name`), one row per group session."""
     conn = sqlite3.connect(str(path))
-    conn.execute("CREATE TABLE sessions (session_id TEXT)")
+    conn.execute(
+        "CREATE TABLE sessions ("
+        "  group_folder TEXT NOT NULL,"
+        "  session_name TEXT NOT NULL DEFAULT 'default',"
+        "  session_id TEXT NOT NULL,"
+        "  PRIMARY KEY (group_folder, session_name)"
+        ")"
+    )
     if session_id is not None:
-        conn.execute("INSERT INTO sessions (session_id) VALUES (?)", (session_id,))
+        conn.execute(
+            "INSERT INTO sessions (group_folder, session_name, session_id) "
+            "VALUES ('telegram_swarm', 'default', ?)",
+            (session_id,),
+        )
     conn.commit()
     conn.close()
 

--- a/tests/test_system_status_checks.py
+++ b/tests/test_system_status_checks.py
@@ -28,17 +28,31 @@ def system_status_checks():
     return load_script("system_status_checks_under_test", SCRIPT_REL)
 
 
+# Fixed reference time for the recent-failures window (injected via
+# the script's `--now-utc` test seam per `coding-policy:
+# testing-standards` — control the clock, no wall-clock dependence).
+REF_NOW = "2026-07-07T12:00:00Z"
+WITHIN_24H = "2026-07-07T10:00:00.000Z"
+OUTSIDE_24H = "2026-07-05T10:00:00.000Z"
+
+
 def _build_test_db(path) -> None:
-    """Create a minimal `messages.db` with the schema the probe queries.
-    Tests populate rows via `_seed_*` helpers per scenario."""
+    """Create a minimal `messages.db` with the production shape of the
+    tables the probe queries (`task_run_logs` columns per
+    `rules/messages-db-schema.md` — verified against the live host DB).
+    Tests populate rows via `_insert_run_log` per scenario."""
     conn = sqlite3.connect(str(path))
     conn.executescript(
         """
         CREATE TABLE messages (id INTEGER PRIMARY KEY, ts TEXT);
         CREATE TABLE task_run_logs (
-            task_id TEXT,
-            run_at TEXT,
-            last_result TEXT
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            run_at TEXT NOT NULL,
+            duration_ms INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            result TEXT,
+            error TEXT
         );
         CREATE TABLE scheduled_tasks (
             id TEXT PRIMARY KEY,
@@ -50,6 +64,14 @@ def _build_test_db(path) -> None:
     )
     conn.commit()
     conn.close()
+
+
+def _insert_run_log(conn, task_id, run_at, status, *, result=None, error=None):
+    conn.execute(
+        "INSERT INTO task_run_logs (task_id, run_at, duration_ms, status, result, error) "
+        "VALUES (?, ?, 100, ?, ?, ?)",
+        (task_id, run_at, status, result, error),
+    )
 
 
 def _run(module, monkeypatch, capsys, *args):
@@ -116,20 +138,62 @@ def test_recent_task_failure_within_24h(system_status_checks, monkeypatch, capsy
     db = tmp_path / "messages.db"
     _build_test_db(db)
     conn = sqlite3.connect(str(db))
-    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime("%Y-%m-%d %H:%M:%S")
-    conn.execute(
-        "INSERT INTO task_run_logs VALUES ('task-fail-1', ?, 'fatal error: timeout reached')",
-        (recent,),
-    )
+    _insert_run_log(conn, "task-fail-1", WITHIN_24H, "error", error="fatal error: timeout reached")
     conn.commit()
     conn.close()
 
-    code, out, _ = _run(system_status_checks, monkeypatch, capsys, "--db", str(db))
+    code, out, _ = _run(
+        system_status_checks, monkeypatch, capsys, "--db", str(db), "--now-utc", REF_NOW
+    )
     payload = json.loads(out)
     assert code == 0
     assert len(payload["recent_failures"]) == 1
     assert payload["recent_failures"][0]["task_id"] == "task-fail-1"
+    assert payload["recent_failures"][0]["error_summary"] == "fatal error: timeout reached"
     assert any("recent task failures" in a for a in payload["alerts"])
+
+
+def test_killed_run_counts_as_failure_with_result_fallback(
+    system_status_checks, monkeypatch, capsys, tmp_path
+):
+    """`killed` is a failure status; with `error` NULL the summary
+    falls back to `result`."""
+    db = tmp_path / "messages.db"
+    _build_test_db(db)
+    conn = sqlite3.connect(str(db))
+    _insert_run_log(conn, "task-killed-1", WITHIN_24H, "killed", result="timed out after 600s")
+    conn.commit()
+    conn.close()
+
+    code, out, _ = _run(
+        system_status_checks, monkeypatch, capsys, "--db", str(db), "--now-utc", REF_NOW
+    )
+    payload = json.loads(out)
+    assert code == 0
+    assert len(payload["recent_failures"]) == 1
+    assert payload["recent_failures"][0]["error_summary"] == "timed out after 600s"
+
+
+def test_non_failure_statuses_within_window_are_excluded(
+    system_status_checks, monkeypatch, capsys, tmp_path
+):
+    """`success` and `precheck_skipped` runs are not failures even when
+    their `result` text happens to contain the word "error" — the
+    filter keys on `status`, not on substring-matching free text."""
+    db = tmp_path / "messages.db"
+    _build_test_db(db)
+    conn = sqlite3.connect(str(db))
+    _insert_run_log(conn, "task-ok", WITHIN_24H, "success", result="recovered from error, all good")
+    _insert_run_log(conn, "task-skip", WITHIN_24H, "precheck_skipped", result='{"events":[]}')
+    conn.commit()
+    conn.close()
+
+    code, out, _ = _run(
+        system_status_checks, monkeypatch, capsys, "--db", str(db), "--now-utc", REF_NOW
+    )
+    payload = json.loads(out)
+    assert code == 0
+    assert payload["recent_failures"] == []
 
 
 def test_old_task_failure_outside_24h_window_is_excluded(
@@ -138,18 +202,31 @@ def test_old_task_failure_outside_24h_window_is_excluded(
     db = tmp_path / "messages.db"
     _build_test_db(db)
     conn = sqlite3.connect(str(db))
-    old = (datetime.now(timezone.utc) - timedelta(hours=48)).strftime("%Y-%m-%d %H:%M:%S")
-    conn.execute(
-        "INSERT INTO task_run_logs VALUES ('task-old', ?, 'error: gone')",
-        (old,),
-    )
+    _insert_run_log(conn, "task-old", OUTSIDE_24H, "error", error="error: gone")
     conn.commit()
     conn.close()
 
-    code, out, _ = _run(system_status_checks, monkeypatch, capsys, "--db", str(db))
+    code, out, _ = _run(
+        system_status_checks, monkeypatch, capsys, "--db", str(db), "--now-utc", REF_NOW
+    )
     payload = json.loads(out)
     assert code == 0
     assert payload["recent_failures"] == []
+
+
+def test_bad_now_utc_format_is_usage_error(system_status_checks, monkeypatch, capsys, tmp_path):
+    db = tmp_path / "messages.db"
+    _build_test_db(db)
+    code, _out, _err = _run(
+        system_status_checks,
+        monkeypatch,
+        capsys,
+        "--db",
+        str(db),
+        "--now-utc",
+        "2026-07-07 12:00:00",  # space separator, not the canonical shape
+    )
+    assert code == 2
 
 
 def test_message_rowcount_above_threshold_alerts(
@@ -190,15 +267,10 @@ def test_task_log_rowcount_above_threshold_alerts(
     db = tmp_path / "messages.db"
     _build_test_db(db)
     conn = sqlite3.connect(str(db))
-    # Pre-date all rows by 48h so they're outside the recent-failures
-    # 24h window — keeps this test focused on the rowcount-threshold
-    # alert and prevents the recent-failures alert from also firing.
-    old = (datetime.now(timezone.utc) - timedelta(hours=48)).strftime("%Y-%m-%d %H:%M:%S")
+    # `success` rows never hit the recent-failures filter — keeps this
+    # test focused on the rowcount-threshold alert.
     for i in range(20):
-        conn.execute(
-            "INSERT INTO task_run_logs VALUES (?, ?, 'success')",
-            (f"task-{i}", old),
-        )
+        _insert_run_log(conn, f"task-{i}", OUTSIDE_24H, "success", result="ok")
     conn.commit()
     conn.close()
 
@@ -210,6 +282,8 @@ def test_task_log_rowcount_above_threshold_alerts(
         str(db),
         "--task-log-row-warn",
         "10",
+        "--now-utc",
+        REF_NOW,
     )
     payload = json.loads(out)
     assert code == 0


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- Document `sessions` and `task_run_logs` in `rules/messages-db-schema.md` with columns verified against the live host `messages.db` (schema dumped over SSH on 2026-07-07), closing the rule-vs-consumers conflict (closes #69)
- Fix a real production bug the verification surfaced: `system-status-checks.py`'s recent-failures probe selected a nonexistent `last_result` column (it lives on `scheduled_tasks`) — every production run raised `OperationalError` and failure detection was silently broken; the 24h window also compared ISO-8601 `T`/`Z` `run_at` values against SQLite `datetime('now')` output
- Probe now filters `status IN ('error','killed')` (observed production values: `success`/`error`/`killed`/`precheck_skipped`), summarizes from `coalesce(error, result)`, and computes the cutoff in Python in the matching ISO shape with a `--now-utc` test seam
- `register-session.py`'s bare `LIMIT 1` on `sessions` (keyed by `group_folder, session_name`) documents its single-row assumption at the query site; both consumers' test fixtures now build production table shapes so future drift fails in tests

## Test plan
- [x] Production schema verified: `ssh nas` → sqlite3 dump of `sessions`, `task_run_logs`, status values, `run_at` format
- [x] `pytest` — 83 passed (new: killed-with-result-fallback, non-failure statuses excluded even when text contains "error", bad `--now-utc` usage error)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pyright` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLfrPrx6AKtooqxwpqvERN