### PR TITLE
docs(github): refresh Copilot instructions for current policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 `jbaruch/nanoclaw-trusted` is a **NanoClaw tile** — an installable package (managed by [`tessl`](https://tessl.io)) that ships behavioural rules and runtime skills for **trusted and main NanoClaw containers**. It is not a standalone application. It is loaded alongside the core tile (`jbaruch/nanoclaw-core`) and provides the trusted-tier layer on top of it.
 
 The tile's two deliverables are:
-1. **Rules** (`rules/*.md`) — markdown files with `alwaysApply: true` YAML frontmatter, injected into the agent's context at runtime.
+1. **Rules** (`rules/*.md`) — markdown files with YAML frontmatter, injected into the agent's context at runtime. Always-on rules declare `alwaysApply: true`; conditional rules declare `alwaysApply: false` plus an `applyTo:` scope (see `README.md` and `jbaruch/coding-policy: rule-frontmatter`).
 2. **Skills** (`skills/*/SKILL.md`) — prose-and-action markdown that the `Skill()` tool executes inside live containers.
 
 ---
@@ -16,7 +16,8 @@ The tile's two deliverables are:
 tile.json                        # Tile manifest: name, version, rules map, skills map
 README.md                        # Auto-maintained rules/skills summary table
 CHANGELOG.md                     # Chronological change log — read before adding anything
-rules/                           # One .md per rule, all with alwaysApply: true frontmatter
+rules/                           # One .md per rule; frontmatter is alwaysApply: true
+                                 # or alwaysApply: false + applyTo: (conditional)
 skills/
   trusted-memory/
     SKILL.md                     # Session bootstrap + rolling memory update skill
@@ -24,6 +25,9 @@ skills/
     scripts/
       needs-bootstrap.py         # Exit 0 = bootstrap needed, exit 1 = skip
       register-session.py        # Atomic state + sentinel writer (fcntl.LOCK_EX)
+      append-to-daily-log.py     # Locked, dedup-filtered daily-log appender
+      append-daily-discovery.py  # Locked, dedup-filtered discoveries appender
+      memory_write.py            # Shared write_atomic + dedup_filter primitives
   system-status/
     SKILL.md                     # Read-only NanoClaw health probe
     scripts/
@@ -32,12 +36,17 @@ tests/
   conftest.py                    # load_script() helper for kebab-case imports
   test_needs_bootstrap.py
   test_register_session.py
+  test_append_to_daily_log.py
+  test_append_daily_discovery.py
+  test_memory_write.py
   test_system_status_checks.py
 pyproject.toml                   # pytest + ruff config (ruff scoped to tests/ only)
-requirements-dev.txt             # pytest==8.3.4  ruff==0.7.4
+pyrightconfig.json               # pyright config (whole repo: scripts + tests)
+requirements-dev.txt             # pytest==8.3.4  ruff==0.7.4  pyright==1.1.408
 .github/workflows/
-  test.yml                       # CI: ruff lint → ruff format check → pytest
-  publish-tile.yml               # On merge to main: skill review → tile lint → publish
+  test.yml                       # CI: ruff lint → ruff format check → pyright → pytest
+  publish-tile.yml               # On merge to main: changed-skills review → tile lint
+                                 # → stamp CHANGELOG → patch-version publish
 ```
 
 ---
@@ -52,16 +61,20 @@ python -m pip install -r requirements-dev.txt
 python -m ruff check tests/
 python -m ruff format --check tests/
 
+# Type-check (whole repo: scripts + tests, per pyrightconfig.json)
+python -m pyright
+
 # Run tests
 python -m pytest
 ```
 
-CI (`test.yml`) runs lint first, then pytest, on every PR and every push to `main`. Both must pass before merging.
+CI (`test.yml`) runs ruff lint, then pyright at zero findings, then pytest, on every PR and every push to `main`. All three must pass before merging.
 
-The publish workflow (`publish-tile.yml`) additionally runs:
+The publish workflow (`publish-tile.yml`) additionally runs, in order:
 ```bash
-tessl skill review --threshold 85 skills/<name>/SKILL.md   # quality gate ≥85
+tessl skill review --threshold 85 skills/<name>/SKILL.md   # changed skills only (git diff loop)
 tessl tile lint .
+# then: stamp CHANGELOG heading → tesslio/patch-version-publish@v1
 ```
 These require the `TESSL_TOKEN` secret and only run on `main`.
 
@@ -75,12 +88,14 @@ These require the `TESSL_TOKEN` secret and only run on `main`.
 - Scripts that perform concurrent file writes take `fcntl.LOCK_EX` on a sibling `<target>.lock` file for the full read-modify-write cycle to prevent clobbering.
 
 ### Rules
-- Every rule file under `rules/` **must** start with YAML frontmatter declaring `alwaysApply: true`:
+- Every rule file under `rules/` **must** start with YAML frontmatter. Always-on rules declare `alwaysApply: true`; conditional rules declare `alwaysApply: false` plus an `applyTo: "<glob list> — <natural-language clause>"` scope:
   ```markdown
   ---
-  alwaysApply: true
+  alwaysApply: false
+  applyTo: "** — when querying messages.db or referencing its column names"
   ---
   ```
+- Pick the scope per `jbaruch/coding-policy: rule-frontmatter` — stay `alwaysApply: true` when the rule mixes file-bound and broad guidance.
 - Cross-tile rule references use explicit wording: `the \`jbaruch/nanoclaw-core\` tile's \`rules/<name>.md\``.
 - Add a corresponding entry to `tile.json` under the `"rules"` key and a row to the `README.md` rules table for every new rule file.
 
@@ -93,7 +108,7 @@ These require the `TESSL_TOKEN` secret and only run on `main`.
 - Keep `"entrypoint": "README.md"` present.
 
 ### CHANGELOG.md
-- Add an entry under `## Unreleased` for every substantive change. The publish action moves unreleased entries to a versioned section.
+- Add an **un-headed `### ` entry block** at the top of the file (below the header comment) for every substantive change — no `## Unreleased` heading, ever. The publish workflow's stamp-changelog step inserts the `## <version> — <date>` heading above the un-headed blocks before publishing.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,13 +27,18 @@ skills/
       register-session.py        # Atomic state + sentinel writer (fcntl.LOCK_EX)
       append-to-daily-log.py     # Locked, dedup-filtered daily-log appender
       append-daily-discovery.py  # Locked, dedup-filtered discoveries appender
-      memory_write.py            # Shared write_atomic + dedup_filter primitives
-                                 # (snake_case on purpose — siblings `import memory_write`;
-                                 # kebab-case would break the import)
+      memory_write.py            # Helper module (not a CLI entrypoint): shared
+                                 # write_atomic + dedup_filter primitives. snake_case
+                                 # on purpose — siblings `import memory_write`;
+                                 # kebab-case would break the import
   system-status/
     SKILL.md                     # Read-only NanoClaw health probe
     scripts/
       system-status-checks.py    # JSON-producing SQLite probe script
+  status/
+    SKILL.md                     # /status — container uptime + environment snapshot
+    scripts/
+      container-uptime.py        # JSON-producing uptime probe (adopted from nanoclaw-core)
 tests/
   conftest.py                    # load_script() helper for kebab-case imports
   test_needs_bootstrap.py
@@ -42,6 +47,7 @@ tests/
   test_append_daily_discovery.py
   test_memory_write.py
   test_system_status_checks.py
+  test_container_uptime.py
 pyproject.toml                   # pytest + ruff config (ruff scoped to tests/ only)
 pyrightconfig.json               # pyright config (whole repo: scripts + tests)
 requirements-dev.txt             # pytest==8.3.4  ruff==0.7.4  pyright==1.1.408
@@ -133,14 +139,20 @@ Tests use `monkeypatch` to redirect all I/O paths (sentinel files, DB paths, sta
 ## Key Concepts for Working in This Tile
 
 ### trusted-memory skill
-Manages session bootstrap and rolling memory updates for trusted containers. Two scripts:
+Manages session bootstrap and rolling memory updates for trusted containers. Four CLI entrypoints plus one helper module:
 - `needs-bootstrap.py` — compares `/tmp/session_bootstrapped` to `$CLAUDE_SESSION_ID`. Exit 0 = bootstrap needed; exit 1 = skip.
 - `register-session.py` — atomically writes `/workspace/group/session-state.json` (schema_version: 1, per-session subtree + back-compat top-level `session_id`) and the sentinel at `/tmp/session_bootstrapped`.
+- `append-to-daily-log.py` — appends line entries to the daily cross-group log under `fcntl.LOCK_EX`, dedup-filtered against existing lines.
+- `append-daily-discovery.py` — appends the four-line discovery block to `daily_discoveries.md` under the same lock; dedup key excludes the timestamp header so retries are idempotent; rejects CR/LF in field values.
+- `memory_write.py` — helper module (`import memory_write`), the single home for `write_atomic` and `dedup_filter`.
 
 State schema is documented in `skills/trusted-memory/state-schema.md`. Reader skills must treat unknown `schema_version > 1` as "no usable prior state".
 
 ### system-status skill
 Read-only SQLite probe against `/workspace/store/messages.db`. Reports stuck scheduled tasks, row counts/DB size alerts, and recent task failures. Does **not** manage the dismiss mechanism (that lives in the admin tile). On clean pass, emits nothing.
+
+### status skill
+`/status` — container uptime + environment snapshot via `container-uptime.py`. Adopted from nanoclaw-core (trusted-tier placement closes an environment-recon gap for untrusted groups). Complements `system-status`: `status` reports this container, `system-status` probes the orchestrator DB.
 
 ### Memory file locations
 | Path | Contents |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,7 +91,8 @@ These require the `TESSL_TOKEN` secret and only run on `main`.
 ## Coding Conventions
 
 ### Scripts
-- Script filenames are **kebab-case** (e.g., `register-session.py`, `needs-bootstrap.py`). This means they cannot be imported with `import`; see the test section below.
+- **CLI entrypoint** filenames are **kebab-case** (e.g., `register-session.py`, `needs-bootstrap.py`). This means they cannot be imported with `import`; see the test section below.
+- **Helper modules** imported by sibling scripts are **snake_case** (e.g., `memory_write.py`, imported as `import memory_write`). This is a deliberate exception to the kebab-case rule — do not rename it to kebab-case or the imports break. The kebab-case rule governs entrypoints only.
 - Every script must emit a **single-line JSON status to stdout** (per `jbaruch/coding-policy: script-delegation`). Exit codes remain the authoritative success signal; JSON is for callers that want to log or inspect.
 - Scripts that perform concurrent file writes take `fcntl.LOCK_EX` on a sibling `<target>.lock` file for the full read-modify-write cycle to prevent clobbering.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,8 @@ skills/
       append-to-daily-log.py     # Locked, dedup-filtered daily-log appender
       append-daily-discovery.py  # Locked, dedup-filtered discoveries appender
       memory_write.py            # Shared write_atomic + dedup_filter primitives
+                                 # (snake_case on purpose — siblings `import memory_write`;
+                                 # kebab-case would break the import)
   system-status/
     SKILL.md                     # Read-only NanoClaw health probe
     scripts/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,8 +93,8 @@ These require the `TESSL_TOKEN` secret and only run on `main`.
 ### Scripts
 - **CLI entrypoint** filenames are **kebab-case** (e.g., `register-session.py`, `needs-bootstrap.py`). This means they cannot be imported with `import`; see the test section below.
 - **Helper modules** imported by sibling scripts are **snake_case** (e.g., `memory_write.py`, imported as `import memory_write`). This is a deliberate exception to the kebab-case rule — do not rename it to kebab-case or the imports break. The kebab-case rule governs entrypoints only.
-- Every script must emit a **single-line JSON status to stdout** (per `jbaruch/coding-policy: script-delegation`). Exit codes remain the authoritative success signal; JSON is for callers that want to log or inspect.
-- Scripts that perform concurrent file writes take `fcntl.LOCK_EX` on a sibling `<target>.lock` file for the full read-modify-write cycle to prevent clobbering.
+- Every **CLI entrypoint** must emit a **single-line JSON status to stdout** (per `jbaruch/coding-policy: script-delegation`). Exit codes remain the authoritative success signal; JSON is for callers that want to log or inspect. Helper modules (e.g., `memory_write.py`) expose functions to their callers and have no stdout contract.
+- Entrypoints that perform concurrent file writes take `fcntl.LOCK_EX` on a sibling `<target>.lock` file for the full read-modify-write cycle to prevent clobbering.
 
 ### Rules
 - Every rule file under `rules/` **must** start with YAML frontmatter. Always-on rules declare `alwaysApply: true`; conditional rules declare `alwaysApply: false` plus an `applyTo: "<glob list> — <natural-language clause>"` scope:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
      them before publishing — do not add it manually (jbaruch/coding-policy:
      context-artifacts). -->
 
+### Docs — refresh `.github/copilot-instructions.md` to current repo policy (`#68`)
+
+Three stale claims steered cloud agents wrong: "every rule uses
+`alwaysApply: true`" (five rules now use `alwaysApply: false` + `applyTo`
+per `jbaruch/coding-policy: rule-frontmatter`), "CI is ruff + pytest"
+(the pyright gate landed in `#55`), and "add CHANGELOG entries under
+`## Unreleased`" (the stamp-changelog step expects un-headed `###` blocks).
+Repo-layout section also caught up with reality: the three newer
+trusted-memory scripts, their test files, `pyrightconfig.json`, and the
+publish workflow's actual step order.
+
 ## 0.1.87 — 2026-07-07
 
 ### Skills — adopt `/status` from nanoclaw-core (`jbaruch/nanoclaw-trusted#71`, `jbaruch/nanoclaw-core#68`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Docs — refresh `.github/copilot-instructions.md` to current repo policy (`#68`)
 
 Three stale claims steered cloud agents wrong: "every rule uses
-`alwaysApply: true`" (five rules now use `alwaysApply: false` + `applyTo`
+`alwaysApply: true`" (nine rules now use `alwaysApply: false` + `applyTo`
 per `jbaruch/coding-policy: rule-frontmatter`), "CI is ruff + pytest"
 (the pyright gate landed in `#55`), and "add CHANGELOG entries under
 `## Unreleased`" (the stamp-changelog step expects un-headed `###` blocks).


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- Fix the three stale claims from #68: rule frontmatter now documents the conditional model (`alwaysApply: false` + `applyTo:`) alongside always-on rules; the CI description gains the pyright gate from #55; CHANGELOG guidance switches from `## Unreleased` to un-headed `###` blocks stamped at publish (closes #68)
- Catch the repo-layout section up: the three newer trusted-memory scripts (`append-to-daily-log.py`, `append-daily-discovery.py`, `memory_write.py`), their test files, `pyrightconfig.json`, pinned `pyright==1.1.408`, and the publish workflow's actual step order (changed-skills review → tile lint → stamp CHANGELOG → patch-version publish)

## Test plan
- [x] Every claim cross-checked against the tree: `requirements-dev.txt`, `.github/workflows/test.yml` steps, `.github/workflows/publish-tile.yml` steps, `ls skills/*/scripts tests/`, rule frontmatter grep
- [x] Docs-only change — `pytest` (83), `ruff`, `pyright` unaffected and green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLfrPrx6AKtooqxwpqvERN