### PR TITLE
fix(trusted-memory): drop swallowed flock-unlock in memory-writer scripts

### DIFF
--- a/skills/trusted-memory/scripts/append-daily-discovery.py
+++ b/skills/trusted-memory/scripts/append-daily-discovery.py
@@ -267,10 +267,7 @@ def main(argv=None) -> int:
             )
             return 1
     finally:
-        try:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
-        except OSError:
-            pass
+        # Closing the fd releases the flock; no explicit LOCK_UN needed.
         lock_f.close()
 
     result["timestamp"] = timestamp if result["appended"] else None

--- a/skills/trusted-memory/scripts/append-to-daily-log.py
+++ b/skills/trusted-memory/scripts/append-to-daily-log.py
@@ -306,8 +306,7 @@ def main(argv=None) -> int:
     try:
         target_dir = _resolve_target_dir(args.target, args)
     except ValueError as exc:
-        parser.error(str(exc))
-        return 2  # parser.error exits 2; this is for type-checkers
+        parser.error(str(exc))  # NoReturn: prints usage to stderr and exits 2
 
     date_str = args.date or _today_utc()
     daily_file = Path(target_dir) / f"{date_str}.md"

--- a/skills/trusted-memory/scripts/append-to-daily-log.py
+++ b/skills/trusted-memory/scripts/append-to-daily-log.py
@@ -347,10 +347,7 @@ def main(argv=None) -> int:
             )
             return 1
     finally:
-        try:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
-        except OSError:
-            pass
+        # Closing the fd releases the flock; no explicit LOCK_UN needed.
         lock_f.close()
 
     if result["out_of_order"]:

--- a/skills/trusted-memory/scripts/register-session.py
+++ b/skills/trusted-memory/scripts/register-session.py
@@ -202,14 +202,7 @@ def main() -> None:
             )
             sys.exit(1)
     finally:
-        # Lock released automatically when lock_f closes, but be
-        # explicit so the intent is obvious to readers.
-        try:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
-        except OSError:
-            # Already released or fd invalidated — lock_f.close() below
-            # handles the rest. Nothing actionable; skip the stderr.
-            pass
+        # Closing the fd releases the flock; no explicit LOCK_UN needed.
         lock_f.close()
 
     # Refuse to write an empty sentinel. An empty string would match the


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## What

Fixes #73.

Three memory-writer scripts shared a `finally`-block idiom that swallowed unlock errors with a bare `except OSError: pass`:

- `skills/trusted-memory/scripts/append-daily-discovery.py`
- `skills/trusted-memory/scripts/append-to-daily-log.py`
- `skills/trusted-memory/scripts/register-session.py`

Closing the lock-file fd releases the flock on its own (standard POSIX), so the explicit `LOCK_UN` was redundant — and it was the only reason the empty `except` existed. Rather than replicate the `register-session` justifying comment to the other two sites, this **removes the explicit unlock entirely**, which deletes the silent-swallow outright per the no-error-swallowing house rule and `jbaruch/coding-policy: error-handling`. `lock_f.close()` is now the single, self-documenting release point.

## Boy-scout: LSP finding in the same file

While editing `append-to-daily-log.py`, Pyright's `reportUnreachable` (a hint in `standard` mode, surfaced in-editor) flagged a dead `return 2` after a `parser.error()` call. `argparse`'s `parser.error()` is typed `NoReturn`, so the return was unreachable — and the old comment (`# this is for type-checkers`) had it backwards. Removed the dead line in a **separate commit**.

## Verification

- `pyright` (repo-wide, with `requirements-dev.txt`): **0 errors, 0 warnings**
- `ruff check tests/` + `ruff format --check tests/`: clean
- `pytest`: **88 passed** (incl. all 49 tests for the three changed scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLfrPrx6AKtooqxwpqvERN