### PR TITLE
ci: de-vendor skill-review to the native credit-outage input

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,18 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps-dev)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+    ignore:
+      # gh-aw-generated review-*.lock.yml files pin a coordinated action set per
+      # compiler version; bump those via `gh aw compile`, not Dependabot.
+      - dependency-name: "actions/cache*"
+      - dependency-name: "actions/download-artifact"
+      - dependency-name: "actions/github-script"
+      - dependency-name: "actions/setup-node"
+      - dependency-name: "actions/upload-artifact"
+      - dependency-name: "github/gh-aw-actions*"

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -26,118 +26,17 @@ jobs:
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
-      # Reviews only the skills whose files changed in this push.
-      #
-      # This step VENDORS the `jbaruch/coding-policy/.github/actions/skill-review`
-      # composite (pinned b63f13e) verbatim, adding one thing the upstream action
-      # cannot yet express: tolerance for a tessl "out of credits" (403) billing
-      # outage. A `uses:` step's failure can't be classified by error content from
-      # the consumer, so the credit-vs-real-failure distinction has to live in a
-      # `run:` step here. Revert to `uses:` once the action grows a native
-      # credit-outage input — tracked in jbaruch/coding-policy#188.
-      #
-      # Tolerance is fail-SAFE and narrow: ONLY a credit-outage signature (the
-      # "run out of credits" phrase AND a 403) skips, publishing unreviewed until
-      # credits reset (monthly, on the 1st); every other non-zero exit still
-      # hard-fails the publish, so a genuine below-threshold score or tooling
-      # error blocks it as before.
+      # Reviews only the skills whose files changed in this push, against the
+      # latest published jbaruch/coding-policy. `credit-outage: skip` skips the
+      # affected skill on a tessl out-of-credits (403) outage (flagged in the
+      # run summary + the action's unreviewed-skills output); every other
+      # review failure still hard-fails. De-vendored now that the native input
+      # exists (jbaruch/coding-policy#188 / #190).
       - name: Skill review (changed only)
-        shell: bash
-        env:
-          EVENT_BEFORE: ${{ github.event.before }}
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_OVERRIDE: ''
-          THRESHOLD: '85'
-          SKILLS_DIR: skills
-        run: |
-          # Pipefail so a failing `git diff` propagates instead of silently
-          # producing an empty changed-skills set (which would skip the
-          # mandatory review per jbaruch/coding-policy `context-artifacts`).
-          set -eo pipefail
-
-          if [ -n "$BASE_OVERRIDE" ]; then
-            base="$BASE_OVERRIDE"
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ] \
-               || [ -z "$EVENT_BEFORE" ] \
-               || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            base=""
-          else
-            base="$EVENT_BEFORE"
-          fi
-          if [ -z "$base" ]; then
-            mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
-            echo "Reviewing all ${#skills[@]} skill(s) (manual trigger or initial push)."
-          else
-            # Validate the base is a real commit before relying on it for
-            # the diff. If not reachable in the local clone, try a shallow
-            # fetch; if that fails too, hard-fail rather than silently
-            # converting an unreachable base into "no changes".
-            if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
-              echo "Base $base not reachable in clone; fetching..."
-              git fetch --no-tags --depth=50 origin "$base" 2>/dev/null \
-                || git fetch --unshallow origin 2>/dev/null \
-                || true
-            fi
-            if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
-              echo "::error::Base $base is not a reachable commit; refusing to silently skip skill review."
-              echo "::error::Set actions/checkout fetch-depth: 0 in the calling workflow, or pass an explicit base-ref."
-              exit 1
-            fi
-            # Strip the SKILLS_DIR prefix from each diff path and pull
-            # out the first path component beneath it — works for any
-            # depth (single-component `skills` or nested `pkg/skills`).
-            mapfile -t skills < <(git diff --name-only "$base..HEAD" -- "$SKILLS_DIR/" \
-              | awk -v prefix="$SKILLS_DIR/" '
-                  index($0, prefix) == 1 {
-                    rest = substr($0, length(prefix) + 1)
-                    slash = index(rest, "/")
-                    if (slash > 0) print substr(rest, 1, slash - 1)
-                  }' | sort -u)
-            echo "Detected ${#skills[@]} changed skill(s) since ${base:0:7}."
-          fi
-          if [ "${#skills[@]}" -eq 0 ]; then
-            echo "No skill changes — review skipped."
-            exit 0
-          fi
-          for skill in "${skills[@]}"; do
-            [ -f "$SKILLS_DIR/$skill/SKILL.md" ] || { echo "  - $skill: deleted, skipping"; continue; }
-            echo "::group::Reviewing $skill"
-            # Capture output so an out-of-credits outage (a billing state, not a
-            # skill defect) can be told apart from a real review failure. Do NOT
-            # blanket-swallow: only the credit signature is tolerated.
-            set +e
-            review_out="$(tessl skill review --threshold "$THRESHOLD" "$SKILLS_DIR/$skill/SKILL.md" 2>&1)"
-            rc=$?
-            set -e
-            printf '%s\n' "$review_out"
-            echo "::endgroup::"
-            [ "$rc" -eq 0 ] && continue
-            # Require BOTH the credit phrase AND the 403 status (fixed-string, not
-            # regex) so only the actual billing outage skips — any other failure
-            # whose text happens to contain the phrase still hard-fails (fail-safe).
-            if printf '%s' "$review_out" | grep -qiF 'run out of credits' \
-               && printf '%s' "$review_out" | grep -qF '403'; then
-              # tessl credits reset monthly on the 1st; name the resume date so the
-              # skip window is legible. The gate self-heals: every publish re-tries,
-              # so a mid-month top-up restores review immediately, and by the 1st
-              # credits are back regardless.
-              # Explicit fallback (not error-swallowing): keeps a date failure
-              # from turning a credit-skip into a hard abort under `set -e`.
-              resume="$(date -u -d "$(date -u +%Y-%m-01) +1 month" +%Y-%m-01)" || resume="the 1st of next month"
-              echo "::warning::tessl org out of credits (403) — skipping review for '$skill'. Publishing UNREVIEWED; review resumes by $resume (monthly credit reset)."
-              {
-                echo "### ⚠️ Skill review skipped — tessl credits exhausted"
-                echo ""
-                echo "\`$skill\` was **not** reviewed: the tessl org is out of credits (403)."
-                echo "It is publishing **without** review. The gate self-heals — top up credits to restore it immediately, otherwise it resumes by **$resume** (monthly reset)."
-                echo ""
-                echo "Tracking upstream tooling: jbaruch/coding-policy#188."
-              } >> "$GITHUB_STEP_SUMMARY"
-              continue
-            fi
-            echo "::error::Skill review failed for '$skill' (exit $rc) — not a credits outage; blocking publish."
-            exit "$rc"
-          done
+        uses: jbaruch/coding-policy/.github/actions/skill-review@3e3f74e90f1ff6ae283fedc51a7191d1b628b543
+        with:
+          threshold: '85'
+          credit-outage: 'skip'
 
       - name: Lint plugin
         run: tessl plugin lint .


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

De-vendors the inline `Skill review (changed only)` step in `.github/workflows/publish-tile.yml` back to the shared composite `jbaruch/coding-policy/.github/actions/skill-review`, now pinned at `3e3f74e90f1ff6ae283fedc51a7191d1b628b543`.

The step was previously vendored as a ~90-line inline `run:` block to add tolerance for a tessl out-of-credits (403) billing outage, which a `uses:` step could not express at the time. That tolerance now exists natively as the action's `credit-outage: skip` input (jbaruch/coding-policy#188 / #190), so the vendored copy is replaced with `credit-outage: 'skip'`.

Behavior unchanged: only a credit-outage (403) signature skips the affected skill (flagged in the run summary and the action's unreviewed-skills output); every other review failure still hard-fails the publish. Threshold stays `85`; skills dir stays the default `skills`.

CI-only change — no source, test, or runtime behavior touched.