### PR TITLE
ci(review): refresh review-trigger.yml from the canonical template

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,15 +1,15 @@
 name: Trigger fleet policy review
 
-# PR-time trigger for the central jbaruch/coding-policy fleet reviewer. On every
-# same-repo PR event this fires a single-PR review in coding-policy immediately,
-# so the policy verdict is available before merge (the coding-policy cron poll is
-# only a backstop). Fork PRs are skipped — they cannot read the dispatch secret.
+# On each pull request in this repo, starts a review of that PR against the
+# jbaruch/coding-policy coding rules, so the result is available before merge. The
+# jbaruch/coding-policy schedule reviews the same PRs as a backstop. Fork pull
+# requests are skipped (they cannot read the secret). Dependabot pull requests are
+# skipped too (the dependabot actor gets no secrets); the schedule covers them.
 #
 # Requires one repo secret (set it at
 # https://github.com/<owner>/<repo>/settings/secrets/actions for this repo):
-#   FLEET_DISPATCH_TOKEN — a fine-grained PAT scoped to ONLY jbaruch/coding-policy
-#     with `Actions: write` (nothing else). It can trigger the review workflow and
-#     nothing more. The Codex credential itself lives only in coding-policy.
+#   FLEET_DISPATCH_TOKEN — the token this workflow reads to start the review run in
+#     jbaruch/coding-policy. Create it with Actions: Read and write on jbaruch/coding-policy.
 
 on:
   pull_request:
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   trigger:
     # Fork PRs cannot read secrets — skip them (adopt via the adopt-fork-pr skill).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot's actor also gets no secrets, so its request can't authenticate —
+    # skip it too (the coding-policy cron poll reviews dependabot PRs instead).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the single-PR review to coding-policy
@@ -36,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained PAT (Actions: write on jbaruch/coding-policy only); see this workflow's header" >&2
+            echo "error: FLEET_DISPATCH_TOKEN secret is empty — set a fine-grained token scoped to Actions: Read and write on jbaruch/coding-policy only; see this workflow's header" >&2
             exit 1
           fi
           gh workflow run fleet-review.yml \


### PR DESCRIPTION
Refreshes this repo's `.github/workflows/review-trigger.yml` to match the canonical template at `jbaruch/coding-policy` `skills/install-reviewer/templates/review-trigger.yml.md`.

## Why

All 8 fleet repos carry a byte-identical pre-guard copy. The template gained `github.actor != 'dependabot[bot]'`; the consumers never got it.

Dependabot PRs run against GitHub's **Dependabot** secret store, not the **Actions** store where `FLEET_DISPATCH_TOKEN` lives. So on every dependency PR the workflow fires, reads an empty token, and its own guard exits 1:

```
Secret source: Dependabot
GH_TOKEN:
error: FLEET_DISPATCH_TOKEN secret is empty
```

Nothing went unreviewed — the coding-policy cron poll reviews dependabot PRs as designed, and every such PR merged today carried a real `fleet-reviewer: APPROVED`. The cost was a permanent red check that trains everyone to ignore red.

## What changed

- `if:` gains the `dependabot[bot]` actor guard (the functional fix)
- Header comment documents the dependabot skip and the cron backstop
- Token error message corrected: `Actions: write` → `Actions: Read and write`

Content is the template verbatim, so this repo stops drifting from canonical.