### PR TITLE
chore(ci): bump the reusable publish workflow to the gated + fixed version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   publish:
-    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@b7eb9d08b78f72810891aa5fe7bf3e4fa6eb55f6
+    uses: jbaruch/coding-policy/.github/workflows/publish-plugin.yml@af116ebf18a7c46a672bf176064908736bc8ac28
     # Forward only the token the reusable workflow declares (not `inherit`).
     secrets:
       TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}


### PR DESCRIPTION
**CI-scoped pin bump** (fleet rollout of `jbaruch/coding-policy#292` + `#293`).

This repo pins a pre-gate `publish-plugin.yml` SHA (still `tesslio/patch-version-publish`, no reconciliation), so a post-publish out-of-credits exit reds the run even though the artifact landed. Bump the pin to `af116eb`, which routes publishing through `smart-publish` + the `publish-landed-gate` confirm step with the terminal-signature fix (`#293`): a landed credit-outage publish greens (with a `::warning::`), every non-landing or non-credit failure still reds.

Dependabot would renew this weekly; bumping now to stop reding landed releases during the active credit outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186da3iE7wGaQzsqXPHPymU