### PR TITLE
chore(gitignore): ignore the tessl-generated .github/hooks/ and .cursor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ AGENTS.md
 CLAUDE.md
 .github/skills/
 .github/mcp.json
+.github/hooks/
+.cursor/


### PR DESCRIPTION
`tessl install` writes `.github/hooks/tessl.json` and, on a Cursor-using checkout, `.cursor/`. Both are per-developer resolved state — exactly like the `.github/skills/` and `.github/mcp.json` entries directly above them in the same block. Neither was listed, so `.github/hooks/` sat untracked in every session, one `git add -A` from being committed.

`coding-policy: file-hygiene` Generated Files: a file reproducible from source does not belong in the repo.

## How this surfaced

A staleness sweep of local worktrees and clones. `.github/hooks/` was untracked in **five** live plugin repos; `.cursor/` was unlisted in **six**, and will appear in each on the next `tessl install` from a Cursor checkout.

It was reported once already, as `nanoclaw-orders#71`. I closed that as dead-by-retirement — correct for an archived repo, but I stopped at the repo instead of asking where else the pattern lived. It was live in six.

## Verified, not assumed

Both patterns were exercised against the real paths in this branch:

```
git check-ignore -q .github/hooks/tessl.json   -> IGNORED
git check-ignore -q .cursor/rules/tessl__foo.md -> IGNORED
git status --porcelain | grep -cE 'hooks|cursor' -> 0
```

Same two lines `nanoclaw`, `nanoclaw-admin`, `nanoclaw-host` and `nanoclaw-travel` already carry. No CHANGELOG entry, matching the precedent set by `jbaruch/nanoclaw#938` for a gitignore-only chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Rqq2441WJMN49ShrMiTZ4